### PR TITLE
Haskell benchmark improvements!

### DIFF
--- a/benchmarks/base.for
+++ b/benchmarks/base.for
@@ -60,6 +60,8 @@ let n19 S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-
 let n20 S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-zero))))))))))))))))))))
 let n21 S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-zero)))))))))))))))))))))
 let n22 S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-zero))))))))))))))))))))))
+let n23 S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-zero)))))))))))))))))))))))
+let n24 S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-succ(S-zero))))))))))))))))))))))))
 
 -- A string of 32 bits, all zeroes
 let u32-zero S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-0(S-z)))))))))))))))))))))))))))))))) 

--- a/benchmarks/base.hs
+++ b/benchmarks/base.hs
@@ -83,6 +83,8 @@ n19 = (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s
 n20 = (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ s_zero))))))))))))))))))))
 n21 = (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ s_zero)))))))))))))))))))))
 n22 = (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ s_zero))))))))))))))))))))))
+n23 = (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ s_zero)))))))))))))))))))))))
+n24 = (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ (s_succ s_zero))))))))))))))))))))))))
 
 -- A string of 32 bits, all zeroes
 u32_zero :: S_Bits

--- a/benchmarks/base.js
+++ b/benchmarks/base.js
@@ -70,6 +70,8 @@ const n19 = s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_suc
 const n20 = s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_zero))))))))))))))))))));
 const n21 = s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_zero)))))))))))))))))))));
 const n22 = s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_zero))))))))))))))))))))));
+const n23 = s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_zero)))))))))))))))))))))));
+const n24 = s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_succ(s_zero))))))))))))))))))))))));
 
 // A string of 32 bits, all zeroes
 const u32_zero = s_O(s_O(s_O(s_O(s_O(s_O(s_O(s_O(s_O(s_O(s_O(s_O(s_O(s_O(s_O(s_O( s_O(s_O(s_O(s_O(s_O(s_O(s_O(s_O(s_O(s_O(s_O(s_O(s_O(s_O(s_O(s_O(s_z))))))))))))))))))))))))))))))));
@@ -152,4 +154,4 @@ const flip_unfusible = (function flip_unfusible() {
 })();
 
 
-module.exports = {O, I, z, succ, zero, cons, nil, s_z, s_O, s_I, s_zero, s_succ, s_nil, s_cons, to_Bits, to_List, inc, map, apply_pow2n_times, apply_pow2n_times_bits, double_size, length, flip_unfusible, n0, n1, n2, n3, n4, n5, n6, n7, n8, n9, n10, n11, n12, n13, n14, n15, n16, n17, n18, n19, n20, n21, n22, u32_zero, list_with_100_zeros};
+module.exports = {O, I, z, succ, zero, cons, nil, s_z, s_O, s_I, s_zero, s_succ, s_nil, s_cons, to_Bits, to_List, inc, map, apply_pow2n_times, apply_pow2n_times_bits, double_size, length, flip_unfusible, n0, n1, n2, n3, n4, n5, n6, n7, n8, n9, n10, n11, n12, n13, n14, n15, n16, n17, n18, n19, n20, n21, n22, n23, n24, u32_zero, list_with_100_zeros};

--- a/benchmarks/patternmatch.for
+++ b/benchmarks/patternmatch.for
@@ -1,3 +1,3 @@
 import base
 
-let main to-Bits(apply-pow2n-times-bits(n20, flip-unfusible, u32-zero))
+let main to-Bits(apply-pow2n-times-bits(n24, flip-unfusible, u32-zero))

--- a/benchmarks/patternmatch_identical.hs
+++ b/benchmarks/patternmatch_identical.hs
@@ -1,4 +1,4 @@
 import Base
 
 main :: IO ()
-main = print $ to_Bits (apply_pow2n_times_bits n20 flip_unfusible u32_zero)
+main = print $ to_Bits (apply_pow2n_times_bits n24 flip_unfusible u32_zero)

--- a/benchmarks/patternmatch_identical.js
+++ b/benchmarks/patternmatch_identical.js
@@ -1,3 +1,3 @@
-const {to_Bits, apply_pow2n_times_bits, n20, flip_unfusible, u32_zero} = require("./base.js");
+const {to_Bits, apply_pow2n_times_bits, n24, flip_unfusible, u32_zero} = require("./base.js");
 
-console.log(JSON.stringify(to_Bits(apply_pow2n_times_bits(n20)(flip_unfusible)(u32_zero))));
+console.log(JSON.stringify(to_Bits(apply_pow2n_times_bits(n24)(flip_unfusible)(u32_zero))));

--- a/benchmarks/patternmatch_native.hs
+++ b/benchmarks/patternmatch_native.hs
@@ -17,4 +17,4 @@ u32_zero :: Bits
 u32_zero = (O (O (O (O (O (O (O (O (O (O (O (O (O (O (O (O (O (O (O (O (O (O (O (O (O (O (O (O (O (O (O (O Z))))))))))))))))))))))))))))))))
 
 main :: IO ()
-main = print $ go (2^20) u32_zero
+main = print $ go (2^24) u32_zero

--- a/benchmarks/patternmatch_native.hs
+++ b/benchmarks/patternmatch_native.hs
@@ -1,10 +1,12 @@
+{-# LANGUAGE BangPatterns #-}
+
 import Prelude hiding (flip)
 
 data Bits = O Bits | I Bits | Z deriving Show
 
 flip :: Bits -> Bits
-flip (O bs) = I (flip bs)
-flip (I bs) = O (flip bs)
+flip (O bs) = I bs' where !bs' = flip bs
+flip (I bs) = O bs' where !bs' = flip bs
 flip Z      = Z
 
 go :: Int -> Bits -> Bits

--- a/benchmarks/patternmatch_native.js
+++ b/benchmarks/patternmatch_native.js
@@ -11,7 +11,7 @@ function flip(bits) {
 }
 
 // Flips all bits 2^20 times
-for (var i = 0; i < Math.pow(2, 20); ++i) {
+for (var i = 0; i < Math.pow(2, 24); ++i) {
   bits = flip(bits);
 }
 

--- a/benchmarks/runtimefusion.for
+++ b/benchmarks/runtimefusion.for
@@ -1,3 +1,3 @@
 import base
 
-let main to-List(apply-pow2n-times(n20, map(inc), list-with-100-zeros))
+let main to-List(apply-pow2n-times(n24, map(inc), list-with-100-zeros))

--- a/benchmarks/runtimefusion_identical.hs
+++ b/benchmarks/runtimefusion_identical.hs
@@ -2,4 +2,4 @@ import Base
 import Prelude hiding (map)
 
 main :: IO ()
-main = print . to_List $ apply_pow2n_times n20 (map inc) list_with_100_zeros
+main = print . to_List $ apply_pow2n_times n24 (map inc) list_with_100_zeros

--- a/benchmarks/runtimefusion_identical.js
+++ b/benchmarks/runtimefusion_identical.js
@@ -10,6 +10,6 @@
 // if the trend continued, 2^20 calls would take 819s.
 // TEST VALUES
 
-const {s_succ, s_zero, s_O, s_z, s_cons, s_nil, to_List, apply_pow2n_times, map, inc, n20, u32_zero, list_with_100_zeros} = require("./base.js");
+const {s_succ, s_zero, s_O, s_z, s_cons, s_nil, to_List, apply_pow2n_times, map, inc, n24, u32_zero, list_with_100_zeros} = require("./base.js");
 
-console.log(JSON.stringify(to_List(apply_pow2n_times(n20)(map(inc))(list_with_100_zeros))));
+console.log(JSON.stringify(to_List(apply_pow2n_times(n24)(map(inc))(list_with_100_zeros))));

--- a/benchmarks/runtimefusion_native.hs
+++ b/benchmarks/runtimefusion_native.hs
@@ -16,4 +16,4 @@ map' f (x:xs) = x' : xs'
    !xs' = map' f xs 
 
 main :: IO ()
-main = print $ apply_n_times (2^20) (map' (+ 1)) list
+main = print $ apply_n_times (2^24) (map' (+ 1)) list

--- a/benchmarks/runtimefusion_native.hs
+++ b/benchmarks/runtimefusion_native.hs
@@ -1,9 +1,19 @@
+{-# LANGUAGE BangPatterns #-}
+
 apply_n_times :: Int -> (a -> a) -> a -> a
 apply_n_times 0 f x = x
 apply_n_times n f x = apply_n_times (n - 1) f (f x)
 
 list :: [Int]
-list = map (const 0) [0..100]
+list = replicate 100 0
+
+map' :: (a -> b) -> [a] -> [b]
+map' f []     = []
+map' f (x:xs) = x' : xs'
+
+   where
+   !x'  = f x
+   !xs' = map' f xs 
 
 main :: IO ()
-main = print $ apply_n_times (2^20) (map (+ 1)) list
+main = print $ apply_n_times (2^20) (map' (+ 1)) list

--- a/benchmarks/runtimefusion_native.js
+++ b/benchmarks/runtimefusion_native.js
@@ -1,6 +1,6 @@
 var list = Array(100).fill(0);
 
-for (var i = 0; i < Math.pow(2, 20); ++i) {
+for (var i = 0; i < Math.pow(2, 24); ++i) {
   list = list.map(x => x + 1);
 }
 


### PR DESCRIPTION
This improves the performance of Haskell code. On my machine (little bit slower than yours) it takes:

| patternmatch_native.hs | runtimefusion_native.hs |
| --- | --- |
| ~0.25s | ~1s |

I did not change the `Readme.md` because I have different machine than you, so don't forget to update the timings.