### PR TITLE
fix: export to-js

### DIFF
--- a/src/exports.js
+++ b/src/exports.js
@@ -3,6 +3,7 @@ var fm = module.exports = {
   lang: require("./fm-lang.js"),
   net: require("./fm-net.js"),
   to_net: require("./fm-to-net.js"),
+  to_js: require("./fm-to-js.js"),
 };
 
 // All-in-one convenience export


### PR DESCRIPTION
The to_js module was not being exported, causing an error when calling the exec with "JAVASCRIPT" argument.