### PR TITLE
simplify fm-lang by parametrizing the file loader

### DIFF
--- a/src/exports.js
+++ b/src/exports.js
@@ -3,7 +3,8 @@ var fm = module.exports = {
   lang: require("./fm-lang.js"),
   net: require("./fm-net.js"),
   to_net: require("./fm-to-net.js"),
-  to_js: require("./fm-to-js.js")
+  to_js: require("./fm-to-js.js"),
+  forall: require("./forall"),
 };
 
 // All-in-one convenience export

--- a/src/fm-lang.js
+++ b/src/fm-lang.js
@@ -59,11 +59,7 @@ const {
   ctx_names,
 } = require("./fm-core.js");
 
-// Usng eval prevents being catched by Webpack
-const fs = typeof window === "object" ? null : eval('require("fs")');
-const ls = typeof window === "object" ? window.localStorage : null;
-const path = typeof window === "object" ? null : eval('require("path")');
-const xhr = require("xhr-request-promise");
+const { load_file } = require("./forall");
 const version = require("./../package.json").version;
 
 // :::::::::::::::::::::
@@ -330,16 +326,13 @@ const show = ([ctor, args], nams = [], opts = {}) => {
 // :::::::::::::
 
 // Converts a string to a term
-const parse = async (file, code, tokenify, root = true, loaded = {}) => {
+const parse = async (file, code, tokenify, loader = load_file, root = true, loaded = {}) => {
   // Imports a local/global file, merging its definitions
   async function do_import(import_file) {
-    if (import_file.indexOf("@") === -1) {
-      local_imports[import_file] = true;
-    }
     if (!loaded[import_file]) {
       try {
-        var file_code = await load_file(import_file);
-        loaded[import_file] = await parse(import_file, file_code, tokenify, false, loaded);
+        var file_code = await loader(import_file);
+        loaded[import_file] = await parse(import_file, file_code, tokenify, loader, false, loaded);
       } catch (e) {
         throw e;
       }
@@ -413,7 +406,7 @@ const parse = async (file, code, tokenify, root = true, loaded = {}) => {
           return found[0];
         }
       }
-      // Otherwise, return an undefined reference to hte same file 
+      // Otherwise, return an undefined reference to hte same file
       return file + "/" + str_name;
     })();
     return result;
@@ -1080,7 +1073,7 @@ const parse = async (file, code, tokenify, root = true, loaded = {}) => {
     }
   }
 
-  // Parses a self type, `$x P(x)` 
+  // Parses a self type, `$x P(x)`
   function parse_slf(nams) {
     if (match("$")) {
       var name = parse_string();
@@ -1519,7 +1512,7 @@ const parse = async (file, code, tokenify, root = true, loaded = {}) => {
   // Parses a top-level definition, including:
   //
   // - Untyped definitions:
-  // 
+  //
   //   name <term>
   //
   // - Typed definitions:
@@ -2031,7 +2024,6 @@ const parse = async (file, code, tokenify, root = true, loaded = {}) => {
   // Parses all definitions
   var open_imports = {};
   var qual_imports = {};
-  var local_imports = {};
   var file_version = {};
   var tokens = tokenify ? [["txt",""]] : null;
   var idx = 0;
@@ -2059,7 +2051,6 @@ const parse = async (file, code, tokenify, root = true, loaded = {}) => {
     adts,
     unbx,
     tokens,
-    local_imports,
     qual_imports,
     open_imports
   };
@@ -2382,10 +2373,10 @@ const replace = (idx, val, term) => {
 // :::::::::::::::::::
 
 // Syntax sugars for datatypes. They transform a statement like:
-// 
+//
 //   data ADT <p0 : Param0, p1 : Param1...> {i0 : Index0, i1 : Index1}
-//   | ctr0 {ctr_fld0 : Ctr0_Fld0, ctr0_fld1 : Ctr0_Fld1, ...} : Cr0Type 
-//   | ctr1 {ctr_fld0 : Ctr0_Fld0, ctr0_fld1 : Ctr0_Fld1, ...} : Cr0Type 
+//   | ctr0 {ctr_fld0 : Ctr0_Fld0, ctr0_fld1 : Ctr0_Fld1, ...} : Cr0Type
+//   | ctr1 {ctr_fld0 : Ctr0_Fld0, ctr0_fld1 : Ctr0_Fld1, ...} : Cr0Type
 //   | ...
 //
 // on its corresponding self-encoded datatype:
@@ -2399,12 +2390,12 @@ const replace = (idx, val, term) => {
 //     {ctr1 : {ctr1_fld0 : Ctr1_Fld0, ctr1_fld1 : Ctr1_Fld1, ...} -> (Ctr0Type[ADT <- P] (ADT.ctr1 Param0 Param1... ctr1_fld1 ctr0_fld1 ...))} ->
 //     ... ->
 //     (P i0 i1... self)
-//  
+//
 //   def ADT.ctr0
 //   = {~p0 : Param0, ~p1 : Param1, ..., ctr0_fld0 : Ctr0_Fld0, ctr1_fld1 : Ctr1_Fld1, ...} =>
 //     : Ctr0Type
 //     @ Ctr0Type
-//       {~P, ctr0, ctr1, ...} => 
+//       {~P, ctr0, ctr1, ...} =>
 //       (ctr0 ctr0_fld0 ctr0_fld1 ...)
 //
 //   (...)
@@ -2440,7 +2431,7 @@ const derive_adt_type = (file, {adt_pram, adt_indx, adt_ctor, adt_name}) => {
             } else {
               var wit_t = Ref(file+"/"+adt_name);
               for (var P = 0; P < adt_pram.length; ++P) {
-                wit_t = App(wit_t, Var(-1 + i + 1 + i + adt_pram.length - P), adt_pram[P][2]); 
+                wit_t = App(wit_t, Var(-1 + i + 1 + i + adt_pram.length - P), adt_pram[P][2]);
               }
               for (var I = 0; I < i; ++I) {
                 wit_t = App(wit_t, Var(-1 + i - I), adt_indx[I][2]);
@@ -2488,7 +2479,7 @@ const derive_adt_type = (file, {adt_pram, adt_indx, adt_ctor, adt_name}) => {
             // ... (P i0 i1... self)
             var ret = Var(adt_ctor.length + 1 - 1);
             for (var i = 0; i < adt_indx.length; ++i) {
-              var ret = App(ret, Var(adt_ctor.length + 1 + 1 + adt_indx.length - i - 1), adt_indx[i][2]); 
+              var ret = App(ret, Var(adt_ctor.length + 1 + 1 + adt_indx.length - i - 1), adt_indx[i][2]);
             }
             var ret = App(ret, Var(adt_ctor.length + 1 + 1 - 1), false);
             return ret;
@@ -2530,90 +2521,6 @@ const derive_adt_ctor = (file, {adt_pram, adt_indx, adt_ctor, adt_name}, c) => {
     }
   })(0, adt_indx.length, 0);
 }
-
-const post = (func, body) => {
-  return xhr("http://moonad.org/api/" + func,
-    { method: "POST"
-    , json: true
-    , body})
-    .then(res => {
-      if (res[0] === "ok") {
-        return res[1];
-      } else {
-        throw res[1];
-      }
-    });
-};
-
-const save_file = (file, code) => post("save_file", {file, code});
-const load_file_parents = (file) => post("load_file_parents", {file});
-const load_file = (() => {
-  var loading = {};
-  var warned = false;
-  return (file) => {
-    if (!loading[file]) {
-
-      if (fs) {
-        var cache_dir_path = path.join(process.cwd(), "fm_modules");
-        var cached_file_path = path.join(cache_dir_path, file + ".fm");
-        var local_file_path = path.join(process.cwd(), file + ".fm");
-        var version_file_path = path.join(cache_dir_path, "version");
-        var has_cache_dir = fs.existsSync(cache_dir_path);
-        var has_version_file = has_cache_dir && fs.existsSync(version_file_path);
-        var correct_version = has_version_file && fs.readFileSync(version_file_path, "utf8") === version;
-        if (!has_cache_dir || !has_version_file || !correct_version) {
-          if (has_cache_dir) {
-            var files = fs.readdirSync(cache_dir_path);
-            for (var i = 0; i < files.length; ++i) {
-              fs.unlinkSync(path.join(cache_dir_path, files[i]));
-            }
-            fs.rmdirSync(cache_dir_path);
-          }
-          fs.mkdirSync(cache_dir_path);
-          fs.writeFileSync(version_file_path, version);
-        }
-      }
-
-      var has_cached_fs = fs && fs.existsSync(cached_file_path);
-      var has_local_fs = fs && fs.existsSync(local_file_path);
-      if (has_cached_fs || has_local_fs) {
-        loading[file] = new Promise((resolve, reject) => {
-          fs.readFile(has_cached_fs ? cached_file_path : local_file_path, "utf8", (err, code) => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve(code);
-            }
-          })
-        });
-
-      } else {
-        var cached_ls = ls && ls.getItem("FPM@" + version + "/" + file);
-        if (cached_ls) {
-          loading[file] = Promise.resolve(cached_ls);
-        } else {
-          loading[file] = post("load_file", {file}).then(code => new Promise((resolve, reject) => {
-            if (code) {
-              if (fs && !fs.existsSync(cached_file_path)) {
-                if (!warned) {
-                  warned = true;
-                  console.log("Downloading files to `fm_modules`. This may take a while...");
-                }
-                fs.writeFile(cached_file_path, code, (err, ok) => resolve(code));
-              } else if (ls) {
-                ls.setItem("FPM@" + version + "/" + file, code);
-                resolve(code);
-              } else {
-                resolve(code);
-              }
-            }
-          }));
-        }
-      }
-    }
-    return loading[file];
-  };
-})();
 
 module.exports = {
   Var,
@@ -2664,8 +2571,5 @@ module.exports = {
   derive_adt_type,
   derive_adt_ctor,
   //derive_dependent_match,
-  save_file,
-  load_file,
-  load_file_parents,
   version,
 };

--- a/src/forall.js
+++ b/src/forall.js
@@ -1,0 +1,148 @@
+// This module is responsible for loading and publishing files from the Forall repository
+// For now this is using the deprecated moonad.org/api repository, but will be updated to the newer
+// Forall API once the service is deployed and ready to be used.
+//
+// This also exports a few "loader decorators" to enable caching depending on the environment
+
+const xhr = require("xhr-request-promise");
+const version = require("./../package.json").version;
+
+// Load file related things only on node
+const {fs, path, async_read_file, async_write_file} = (
+  typeof window === "object"
+  ? () => ({})
+  : () => {
+    const {promisify} = eval('require("util")');
+    const path = eval('require("path")');
+    const fs = eval('require("fs")');
+
+    const async_read_file = promisify(fs.readFile)
+    const async_write_file = promisify(fs.writeFile)
+
+    return {fs, path, async_read_file, async_write_file}
+  }
+)()
+
+// load_file receives the name of the file and returns the code asyncronously
+//
+// load_file(file: String) -> Promise<String>
+const load_file = (file) => post("load_file", {file});
+
+// save_file receives the file name without the version, the code, and returns, asynchronously
+// the saved global file name (with the version after the @).
+//
+// save_file(file: String, code: String) -> Promise<String>
+const save_file = (file, code) => post("save_file", {file, code});
+
+// Receives a file name and returns a list of parents for that file
+//
+// load_file_parents(file: String) -> Promise<String[]>
+const load_file_parents = (file) => post("load_file_parents", {file});
+
+// Transforms a file loader in order to add local file system cache.
+// It receives the file loader and optionally, a path to save the files
+//
+// with_file_system_cache(
+//   loader: String -> Promise<String>,
+//   cache_dir_path?: String
+// ) -> Promise<String>
+const with_file_system_cache = (loader, cache_dir_path) => async (file) => {
+  const dir_path = cache_dir_path || get_default_fs_cache_path();
+  setup_cache_dir(dir_path);
+  const cached_file_path = path.join(dir_path, file + ".fm");
+  if(fs.existsSync(cached_file_path)) {
+    return await async_read_file(cached_file_path, "utf8");
+  }
+
+  const code = await loader(file)
+
+  await async_write_file(cached_file_path, code, "utf8");
+
+  return code;
+}
+
+// Transforms a file loader in order to add local files for development.
+// It receives the file loader and optionally, a path where the files are
+//
+// with_local_files(
+//   loader: String -> Promise<String>,
+//   local_dir_path?: String
+// ) -> Promise<String>
+const with_local_files = (loader, local_dir_path) => async (file) => {
+  const dir_path = local_dir_path || process.cwd();
+  const local_file_path = path.join(dir_path, file + ".fm");
+  const has_local_file = fs.existsSync(local_file_path);
+
+  if(has_local_file) {
+    return await async_read_file(local_file_path, "utf8");
+  }
+
+  return await loader(file);
+}
+
+// Transforms a file loader in order to add local file system cache.
+// It receives the file loader and optionally, a prefix for the local storage key
+// defaulting to `FPM@${FM_VERSION}/`
+//
+// with_local_storage_cache(
+//   loader: String -> Promise<String>,
+//   prefix?: String
+// ) -> Promise<String>
+const with_local_storage_cache = (loader, prefix = `FPM@${version}/`) => async (file) => {
+  const cached = window.localStorage.getItem(prefix + file)
+  if(cached) {
+    return cached;
+  }
+
+  const code = await loader(file)
+
+  window.localStorage.setItem(prefix + file, code)
+
+  return code;
+}
+
+module.exports = {
+  load_file_parents,
+  load_file,
+  save_file,
+  with_file_system_cache,
+  with_local_files,
+  with_local_storage_cache,
+}
+
+// Utils not exported
+
+const get_default_fs_cache_path = () => path.join(process.cwd(), "fm_modules");
+
+const setup_cache_dir = (cache_dir_path) => {
+  var version_file_path = path.join(cache_dir_path, "version");
+  var has_cache_dir = fs.existsSync(cache_dir_path);
+  var has_version_file = has_cache_dir && fs.existsSync(version_file_path);
+  var correct_version = has_version_file && fs.readFileSync(version_file_path, "utf8") === version;
+  if (!has_cache_dir || !has_version_file || !correct_version) {
+    if (has_cache_dir) {
+      var files = fs.readdirSync(cache_dir_path);
+      for (var i = 0; i < files.length; ++i) {
+        fs.unlinkSync(path.join(cache_dir_path, files[i]));
+      }
+      fs.rmdirSync(cache_dir_path);
+    }
+    fs.mkdirSync(cache_dir_path);
+    fs.writeFileSync(version_file_path, version);
+  }
+}
+
+// The current API is just a simple RPC, so this function helps a lot
+const post = (func, body) => {
+  return xhr("http://moonad.org/api/" + func,
+    { method: "POST"
+    , json: true
+    , body})
+    .then(res => {
+      if (res[0] === "ok") {
+        return res[1];
+      } else {
+        throw res[1];
+      }
+    });
+};


### PR DESCRIPTION
Before, the fm-lang module contained all the logic for loading files.
This commit moves this logic to a module named forall.

Also, this makes the default loader work without any caching and make
caching just composable higher order functions.

That makes integrating formality into different environments easier.