### PR TITLE
feat: exec helper module with json call

### DIFF
--- a/src/exports.js
+++ b/src/exports.js
@@ -6,53 +6,5 @@ var fm = module.exports = {
   to_js: require("./fm-to-js.js"),
   forall: require("./forall"),
   json: require("./fm-json"),
+  exec: require("./fm-exec"),
 };
-
-// All-in-one convenience export
-fm.exec = function exec(name, defs, mode = "DEBUG", opts, stats = {}) {
-  function norm(term, defs, mode = "DEBUG", opts, stats = {}) {
-    var erase = opts.erased ? fm.lang.erase : (x => x);
-    switch (mode) {
-      case "DEBUG":
-        var erased = erase(term);
-        try {
-          var normal = fm.lang.norm(erased, defs, {weak: opts.weak, unbox: opts.unbox, logging: opts.logging});
-        } catch (e) {
-          var normal = fm.lang.norm(erased, defs, {weak: true, unbox: opts.unbox, logging: opts.logging});
-        }
-        return normal;
-      case "JAVASCRIPT":
-        return fm.to_js.decompile(fm.to_js.compile(fm.lang.erase(term, defs), defs));
-      case "OPTIMAL":
-        var net = fm.to_net.compile(fm.lang.erase(term, defs), defs);
-        if (stats && stats.input_net === null) {
-          stats.input_net = JSON.parse(JSON.stringify(net));
-        }
-        if (opts.strict) {
-          var new_stats = net.reduce_strict(stats || {});
-        } else {
-          var new_stats = net.reduce_lazy(stats || {});
-        }
-        if (stats && stats.output_net !== undefined) {
-          stats.output_net = JSON.parse(JSON.stringify(net));
-        }
-        return fm.to_net.decompile(net);
-      case "TYPE":
-        fm.lang.boxcheck(term, defs);
-        return fm.lang.norm(erase(fm.lang.typecheck(term, null, defs)), {}, {weak: false, unbox: true});
-      case "NONE":
-        if (term[0] === "Ref") {
-          return erase(defs[term[1].name]);
-        } else {
-          return erase(term);
-        }
-    }
-  }
-  if (defs[name] && defs[name][0] === "Ref" && !defs[defs[name][1].name]) {
-    name = defs[name][1].name;
-  }
-  var term = defs[name] || fm.lang.Ref(name);
-  var result = norm(term, defs, mode, opts, stats);
-  return result;
-}
-

--- a/src/fm-exec.js
+++ b/src/fm-exec.js
@@ -1,0 +1,114 @@
+const lang = require("./fm-lang");
+const to_net = require("./fm-to-net");
+const to_js = require("./fm-to-js");
+const json = require("./fm-json");
+
+// Return a term or a reference to it based on a name
+function name_to_term(name, defs) {
+  if (defs[name] && defs[name][0] === "Ref" && !defs[defs[name][1].name]) {
+    name = defs[name][1].name;
+  }
+  return defs[name] || lang.Ref(name);
+}
+
+// Returns the type of a term. Can pass a term or a name to it.
+function type(term_or_name, defs, opts = {}) {
+  const term = name_to_term_if_not_term(term_or_name, defs);
+  lang.boxcheck(term, defs);
+  const type = lang.typecheck(term, null, defs)
+
+  return lang.norm(
+    opts.erased ? lang.erase(type) : type,
+    {},
+    {weak: false, unbox: true}
+  )
+}
+
+// Reduces a term to it's normal form using the optimal algorithm.
+function optimal_reduce(term_or_name, defs, opts = {}) {
+  const term = name_to_term_if_not_term(term_or_name, defs);
+  let stats = opts.stats || {}
+  let net = to_net.compile(lang.erase(term, defs), defs);
+
+  if (stats.input_net === null) {
+    stats.input_net = clone(net);
+  }
+
+  if (opts.strict) {
+    net.reduce_strict(stats);
+  } else {
+    net.reduce_lazy(stats);
+  }
+
+  if (stats.output_net !== undefined) {
+    stats.output_net = clone(net);
+  }
+
+  return to_net.decompile(net);
+}
+
+// Reduces a term to it's normal form using javascript functions (beta reduction)
+function beta_reduce(term_or_name, defs, opts = {}) {
+  const term = name_to_term_if_not_term(term_or_name, defs);
+  return to_js.decompile(to_js.compile(lang.erase(term, defs), defs));
+}
+
+// Reduces a term to it's normal form using it's AST so it keeps more info that is useful for debug
+// If weak is set to false, it will first try a non-weak reduction but if it fails it will fallback
+// to a weak reduction.
+function debug_reduce(term_or_name, defs, opts = {}) {
+  const {erased, weak, unbox, logging} = opts;
+
+  const term = name_to_term_if_not_term(term_or_name, defs);
+  const erased_term = erased ? lang.erase(term) : term;
+
+  try {
+    return lang.norm(erased_term, defs, {unbox, logging, weak});
+  } catch (e) {
+    return lang.norm(erased_term, defs, {unbox, logging, weak: true});
+  }
+}
+
+// Calls a formality function with a JS value using Json interop layer
+// You can optionally specify a reducer function to use anything other than optimal reduction
+function json_call(term_or_name, defs, argument, opts = {}) {
+  const term = name_to_term_if_not_term(term_or_name, defs);
+
+  lang.typecheck(term, json_to_json_type_term, defs);
+
+  const argument_term = json.to(argument);
+  const default_reducer = (term) => optimal_reduce(term, defs);
+  const reducer = opts.reducer || default_reducer;
+  const app_term = lang.App(term, argument_term, false);
+  return json.from(reducer(app_term))
+}
+
+module.exports = {
+  name_to_term,
+  type,
+  optimal_reduce,
+  beta_reduce,
+  debug_reduce,
+  json_call
+}
+
+// Private helpers
+
+function name_to_term_if_not_term(term_or_name, defs) {
+  if(typeof term_or_name === "string") {
+    return name_to_term(term_or_name, defs);
+  }
+
+  return term_or_name;
+}
+
+function clone(obj) {
+  return JSON.parse(JSON.stringify(obj))
+}
+
+const json_type = 'Data.Json@0/Json'
+const json_to_json_type_term = lang.All(
+  "",
+  lang.Ref(json_type),
+  lang.Ref(json_type)
+)

--- a/src/main.js
+++ b/src/main.js
@@ -126,14 +126,6 @@ async function upload(file, global_path = {}) {
 
   } else {
     try {
-      var mode
-        = args.d ? "DEBUG"
-        : args.o ? "OPTIMAL"
-        : args.O ? "OPTIMAL"
-        : args.j ? "JAVASCRIPT"
-        : args.t ? "TYPE"
-        : args[0] ? "NONE"
-        : "DEBUG";
       var BOLD = str => "\x1b[4m" + str + "\x1b[0m";
 
       var [file, name] = main.indexOf("/") === -1 ? [main, "main"] : main.split("/");
@@ -186,7 +178,16 @@ async function upload(file, global_path = {}) {
           }
           try {
             if (defs[nams[i]]) {
-              var term = fm.exec(nams[i], defs, mode, opts, stats);
+
+              var term
+                = args.d ? fm.exec.debug_reduce(nams[i], defs, opts)
+                : args.o ? fm.exec.optimal_reduce(nams[i], defs, {...opts, stats})
+                : args.O ? fm.exec.optimal_reduce(nams[i], defs, {...opts, stats})
+                : args.j ? fm.exec.beta_reduce(nams[i], defs, opts)
+                : args.t ? fm.exec.type(nams[i], defs, opts)
+                : args[0] ? (args.X ? term : fm.lang.erase(term))
+                : fm.exec.debug_reduce(nams[i], defs, opts);
+
               console.log(init + fm.lang.show(term, [], {full_refs: !!args.f}));
             } else {
               console.log(init + "Definition not found: " + nams[i]);
@@ -199,7 +200,7 @@ async function upload(file, global_path = {}) {
               //console.log(e.toString());
             }
           }
-          if (args.p || (mode.slice(0,3) === "OPT" && !args.h)) {
+          if (args.p || ((args.o || args.O) && !args.h)) {
             console.log(JSON.stringify(stats));
           }
         }


### PR DESCRIPTION
The exec function is now split into multiple functions for each type of operation.

- `name_to_term` returns a term or a reference term to it given a name
- `type` returns the normalized type of a given term
- `optimal_reduce` - reduces a term to its normal form using optimal algorithm (inet)
- `beta_reduce` - reduces a term to its normal form by compiling to and from JS
- `debug_reduce` - reduces the term using operating directly on the terms, keeping some useful information for debug (such as bind names)
- `json_call` - calls a term of type `Json -> Json` with any JSON valid JS value and does all the translation and typechecking