### PR TITLE
fix: redeclaration of variable term in subst

### DIFF
--- a/src/fm-core.js
+++ b/src/fm-core.js
@@ -321,8 +321,8 @@ const subst = ([ctor, term], val, depth) => {
       var prof = subst(term.prof, val, depth);
       return Cng(func, prof);
     case "Eta":
-      var term = subst(term.expr, val, depth);
-      return Eta(term);
+      var new_term = subst(term.expr, val, depth);
+      return Eta(new_term);
     case "Rwt":
       var name = term.name;
       var type = subst(term.type, val && shift(val, 1, 0), depth + 1);


### PR DESCRIPTION
while a lot of runtimes ignore this problem (maybe just with a warning),
some of them don't. Also, some transpilers get confused when redeclaring
variables. For example, now Babel fails to transpile this package.

This is a fix (by simply naming the new variable new_term).