### PR TITLE
feat: squash all non-merged changes

### DIFF
--- a/src/exports.js
+++ b/src/exports.js
@@ -4,54 +4,7 @@ var fm = module.exports = {
   net: require("./fm-net.js"),
   to_net: require("./fm-to-net.js"),
   to_js: require("./fm-to-js.js"),
+  forall: require("./forall"),
   json: require("./fm-json"),
+  exec: require("./fm-exec"),
 };
-
-// All-in-one convenience export
-fm.exec = function exec(name, defs, mode = "DEBUG", opts, stats = {}) {
-  function norm(term, defs, mode = "DEBUG", opts, stats = {}) {
-    var erase = opts.erased ? fm.lang.erase : (x => x);
-    switch (mode) {
-      case "DEBUG":
-        var erased = erase(term);
-        try {
-          var normal = fm.lang.norm(erased, defs, {weak: opts.weak, unbox: opts.unbox, logging: opts.logging});
-        } catch (e) {
-          var normal = fm.lang.norm(erased, defs, {weak: true, unbox: opts.unbox, logging: opts.logging});
-        }
-        return normal;
-      case "JAVASCRIPT":
-        return fm.to_js.decompile(fm.to_js.compile(fm.lang.erase(term, defs), defs));
-      case "OPTIMAL":
-        var net = fm.to_net.compile(fm.lang.erase(term, defs), defs);
-        if (stats && stats.input_net === null) {
-          stats.input_net = JSON.parse(JSON.stringify(net));
-        }
-        if (opts.strict) {
-          var new_stats = net.reduce_strict(stats || {});
-        } else {
-          var new_stats = net.reduce_lazy(stats || {});
-        }
-        if (stats && stats.output_net !== undefined) {
-          stats.output_net = JSON.parse(JSON.stringify(net));
-        }
-        return fm.to_net.decompile(net);
-      case "TYPE":
-        fm.lang.boxcheck(term, defs);
-        return fm.lang.norm(erase(fm.lang.typecheck(term, null, defs)), {}, {weak: false, unbox: true});
-      case "NONE":
-        if (term[0] === "Ref") {
-          return erase(defs[term[1].name]);
-        } else {
-          return erase(term);
-        }
-    }
-  }
-  if (defs[name] && defs[name][0] === "Ref" && !defs[defs[name][1].name]) {
-    name = defs[name][1].name;
-  }
-  var term = defs[name] || fm.lang.Ref(name);
-  var result = norm(term, defs, mode, opts, stats);
-  return result;
-}
-

--- a/src/fm-core.js
+++ b/src/fm-core.js
@@ -321,8 +321,8 @@ const subst = ([ctor, term], val, depth) => {
       var prof = subst(term.prof, val, depth);
       return Cng(func, prof);
     case "Eta":
-      var term = subst(term.expr, val, depth);
-      return Eta(term);
+      var new_term = subst(term.expr, val, depth);
+      return Eta(new_term);
     case "Rwt":
       var name = term.name;
       var type = subst(term.type, val && shift(val, 1, 0), depth + 1);

--- a/src/fm-exec.js
+++ b/src/fm-exec.js
@@ -1,0 +1,114 @@
+const lang = require("./fm-lang");
+const to_net = require("./fm-to-net");
+const to_js = require("./fm-to-js");
+const json = require("./fm-json");
+
+// Return a term or a reference to it based on a name
+function name_to_term(name, defs) {
+  if (defs[name] && defs[name][0] === "Ref" && !defs[defs[name][1].name]) {
+    name = defs[name][1].name;
+  }
+  return defs[name] || lang.Ref(name);
+}
+
+// Returns the type of a term. Can pass a term or a name to it.
+function type(term_or_name, defs, opts = {}) {
+  const term = name_to_term_if_not_term(term_or_name, defs);
+  lang.boxcheck(term, defs);
+  const type = lang.typecheck(term, null, defs)
+
+  return lang.norm(
+    opts.erased ? lang.erase(type) : type,
+    {},
+    {weak: false, unbox: true}
+  )
+}
+
+// Reduces a term to it's normal form using the optimal algorithm.
+function optimal_reduce(term_or_name, defs, opts = {}) {
+  const term = name_to_term_if_not_term(term_or_name, defs);
+  let stats = opts.stats || {}
+  let net = to_net.compile(lang.erase(term, defs), defs);
+
+  if (stats.input_net === null) {
+    stats.input_net = clone(net);
+  }
+
+  if (opts.strict) {
+    net.reduce_strict(stats);
+  } else {
+    net.reduce_lazy(stats);
+  }
+
+  if (stats.output_net !== undefined) {
+    stats.output_net = clone(net);
+  }
+
+  return to_net.decompile(net);
+}
+
+// Reduces a term to it's normal form using javascript functions (beta reduction)
+function beta_reduce(term_or_name, defs, opts = {}) {
+  const term = name_to_term_if_not_term(term_or_name, defs);
+  return to_js.decompile(to_js.compile(lang.erase(term, defs), defs));
+}
+
+// Reduces a term to it's normal form using it's AST so it keeps more info that is useful for debug
+// If weak is set to false, it will first try a non-weak reduction but if it fails it will fallback
+// to a weak reduction.
+function debug_reduce(term_or_name, defs, opts = {}) {
+  const {erased, weak, unbox, logging} = opts;
+
+  const term = name_to_term_if_not_term(term_or_name, defs);
+  const erased_term = erased ? lang.erase(term) : term;
+
+  try {
+    return lang.norm(erased_term, defs, {unbox, logging, weak});
+  } catch (e) {
+    return lang.norm(erased_term, defs, {unbox, logging, weak: true});
+  }
+}
+
+// Calls a formality function with a JS value using Json interop layer
+// You can optionally specify a reducer function to use anything other than optimal reduction
+function json_call(term_or_name, defs, argument, opts = {}) {
+  const term = name_to_term_if_not_term(term_or_name, defs);
+
+  lang.typecheck(term, json_to_json_type_term, defs);
+
+  const argument_term = json.to(argument);
+  const default_reducer = (term) => optimal_reduce(term, defs);
+  const reducer = opts.reducer || default_reducer;
+  const app_term = lang.App(term, argument_term, false);
+  return json.from(reducer(app_term))
+}
+
+module.exports = {
+  name_to_term,
+  type,
+  optimal_reduce,
+  beta_reduce,
+  debug_reduce,
+  json_call
+}
+
+// Private helpers
+
+function name_to_term_if_not_term(term_or_name, defs) {
+  if(typeof term_or_name === "string") {
+    return name_to_term(term_or_name, defs);
+  }
+
+  return term_or_name;
+}
+
+function clone(obj) {
+  return JSON.parse(JSON.stringify(obj))
+}
+
+const json_type = 'Data.Json@0/Json'
+const json_to_json_type_term = lang.All(
+  "",
+  lang.Ref(json_type),
+  lang.Ref(json_type)
+)

--- a/src/forall.js
+++ b/src/forall.js
@@ -1,0 +1,148 @@
+// This module is responsible for loading and publishing files from the Forall repository
+// For now this is using the deprecated moonad.org/api repository, but will be updated to the newer
+// Forall API once the service is deployed and ready to be used.
+//
+// This also exports a few "loader decorators" to enable caching depending on the environment
+
+const xhr = require("xhr-request-promise");
+const version = require("./../package.json").version;
+
+// Load file related things only on node
+const {fs, path, async_read_file, async_write_file} = (
+  typeof window === "object"
+  ? () => ({})
+  : () => {
+    const {promisify} = eval('require("util")');
+    const path = eval('require("path")');
+    const fs = eval('require("fs")');
+
+    const async_read_file = promisify(fs.readFile)
+    const async_write_file = promisify(fs.writeFile)
+
+    return {fs, path, async_read_file, async_write_file}
+  }
+)()
+
+// load_file receives the name of the file and returns the code asyncronously
+//
+// load_file(file: String) -> Promise<String>
+const load_file = (file) => post("load_file", {file});
+
+// save_file receives the file name without the version, the code, and returns, asynchronously
+// the saved global file name (with the version after the @).
+//
+// save_file(file: String, code: String) -> Promise<String>
+const save_file = (file, code) => post("save_file", {file, code});
+
+// Receives a file name and returns a list of parents for that file
+//
+// load_file_parents(file: String) -> Promise<String[]>
+const load_file_parents = (file) => post("load_file_parents", {file});
+
+// Transforms a file loader in order to add local file system cache.
+// It receives the file loader and optionally, a path to save the files
+//
+// with_file_system_cache(
+//   loader: String -> Promise<String>,
+//   cache_dir_path?: String
+// ) -> Promise<String>
+const with_file_system_cache = (loader, cache_dir_path) => async (file) => {
+  const dir_path = cache_dir_path || get_default_fs_cache_path();
+  setup_cache_dir(dir_path);
+  const cached_file_path = path.join(dir_path, file + ".fm");
+  if(fs.existsSync(cached_file_path)) {
+    return await async_read_file(cached_file_path, "utf8");
+  }
+
+  const code = await loader(file)
+
+  await async_write_file(cached_file_path, code, "utf8");
+
+  return code;
+}
+
+// Transforms a file loader in order to add local files for development.
+// It receives the file loader and optionally, a path where the files are
+//
+// with_local_files(
+//   loader: String -> Promise<String>,
+//   local_dir_path?: String
+// ) -> Promise<String>
+const with_local_files = (loader, local_dir_path) => async (file) => {
+  const dir_path = local_dir_path || process.cwd();
+  const local_file_path = path.join(dir_path, file + ".fm");
+  const has_local_file = fs.existsSync(local_file_path);
+
+  if(has_local_file) {
+    return await async_read_file(local_file_path, "utf8");
+  }
+
+  return await loader(file);
+}
+
+// Transforms a file loader in order to add local file system cache.
+// It receives the file loader and optionally, a prefix for the local storage key
+// defaulting to `FPM@${FM_VERSION}/`
+//
+// with_local_storage_cache(
+//   loader: String -> Promise<String>,
+//   prefix?: String
+// ) -> Promise<String>
+const with_local_storage_cache = (loader, prefix = `FPM@${version}/`) => async (file) => {
+  const cached = window.localStorage.getItem(prefix + file)
+  if(cached) {
+    return cached;
+  }
+
+  const code = await loader(file)
+
+  window.localStorage.setItem(prefix + file, code)
+
+  return code;
+}
+
+module.exports = {
+  load_file_parents,
+  load_file,
+  save_file,
+  with_file_system_cache,
+  with_local_files,
+  with_local_storage_cache,
+}
+
+// Utils not exported
+
+const get_default_fs_cache_path = () => path.join(process.cwd(), "fm_modules");
+
+const setup_cache_dir = (cache_dir_path) => {
+  var version_file_path = path.join(cache_dir_path, "version");
+  var has_cache_dir = fs.existsSync(cache_dir_path);
+  var has_version_file = has_cache_dir && fs.existsSync(version_file_path);
+  var correct_version = has_version_file && fs.readFileSync(version_file_path, "utf8") === version;
+  if (!has_cache_dir || !has_version_file || !correct_version) {
+    if (has_cache_dir) {
+      var files = fs.readdirSync(cache_dir_path);
+      for (var i = 0; i < files.length; ++i) {
+        fs.unlinkSync(path.join(cache_dir_path, files[i]));
+      }
+      fs.rmdirSync(cache_dir_path);
+    }
+    fs.mkdirSync(cache_dir_path);
+    fs.writeFileSync(version_file_path, version);
+  }
+}
+
+// The current API is just a simple RPC, so this function helps a lot
+const post = (func, body) => {
+  return xhr("http://moonad.org/api/" + func,
+    { method: "POST"
+    , json: true
+    , body})
+    .then(res => {
+      if (res[0] === "ok") {
+        return res[1];
+      } else {
+        throw res[1];
+      }
+    });
+};

--- a/src/main.js
+++ b/src/main.js
@@ -53,28 +53,49 @@ try {
   process.exit();
 }
 
+// Create loader with local files for development and with fm_modules filesystem cache
+let warned_about_dowloading = false
+
+const with_download_warning = (loader) => async (file) => {
+  if(!warned_about_dowloading) {
+    console.log("Downloading files to `fm_modules`. This may take a while...");
+    warned_about_dowloading = true;
+  }
+
+  return await loader(file)
+}
+
+const loader = [
+  with_download_warning,
+  fm.forall.with_file_system_cache,
+  fm.forall.with_local_files
+].reduce((loader, mod) => mod(loader), fm.forall.load_file)
+
+async function local_imports_or_exit(file, code) {
+  try {
+    const {open_imports} = await fm.lang.parse(file, code, false, loader);
+    return Object.keys(open_imports).filter((name) => name.indexOf("@") === -1)
+  } catch (e) {
+    console.log(e.toString());
+    process.exit();
+  }
+}
+
 async function upload(file, global_path = {}) {
   if (!global_path[file]) {
     var code = fs.readFileSync(file + ".fm", "utf8");
 
-    try {
-      var local_imports = (await fm.lang.parse(file, code)).local_imports;
-    } catch (e) {
-      console.log(e.toString());
-      process.exit();
-    }
-    //console.log(file, local_imports);
+    const local_imports = await local_imports_or_exit(file, code);
 
-    for (var imp_file in local_imports) {
+    for (var imp_file of local_imports) {
       var g_path = await upload(imp_file, global_path);
       var [g_name, g_vers] = g_path.split("@");
-      //console.log(file, "replace", "`import " + imp_file + " *`", "by", "`import " + g_name + "@" + g_vers + " as " + imp_file + "`");
       var code = code.replace(new RegExp("import " + imp_file + " *\n")  , "import " + g_name + "@" + g_vers + "\n");
       var code = code.replace(new RegExp("import " + imp_file + " *open"), "import " + g_name + "@" + g_vers + " open");
       var code = code.replace(new RegExp("import " + imp_file + " *as")  , "import " + g_name + "@" + g_vers + " as");
     }
 
-    global_path[file] = await fm.lang.save_file(file, code);
+    global_path[file] = await fm.forall.save_file(file, code);
     console.log("Saved `" + file + "` as `" + global_path[file] + "`!");
   }
   return global_path[file];
@@ -87,13 +108,13 @@ async function upload(file, global_path = {}) {
 
   } else if (args.i) {
     try {
-      console.log((await fm.lang.load_file_parents(main)).map(file => "- " + file).join("\n"));
+      console.log((await fm.forall.load_file_parents(main)).map(file => "- " + file).join("\n"));
     } catch (e) {
       console.log("Couldn't load global file '" + main + "'.");
     }
 
   } else if (args.l) {
-    console.log(fs.writeFileSync(main + ".fm", await fm.lang.load_file(main)));
+    console.log(fs.writeFileSync(main + ".fm", await fm.forall.load_file(main)));
     console.log("Downloaded file as `" + main + ".fm`!");
 
   } else if (args.S || args.s) {
@@ -105,14 +126,6 @@ async function upload(file, global_path = {}) {
 
   } else {
     try {
-      var mode
-        = args.d ? "DEBUG"
-        : args.o ? "OPTIMAL"
-        : args.O ? "OPTIMAL"
-        : args.j ? "JAVASCRIPT"
-        : args.t ? "TYPE"
-        : args[0] ? "NONE"
-        : "DEBUG";
       var BOLD = str => "\x1b[4m" + str + "\x1b[0m";
 
       var [file, name] = main.indexOf("/") === -1 ? [main, "main"] : main.split("/");
@@ -122,7 +135,7 @@ async function upload(file, global_path = {}) {
         console.log("Couldn't find local file `" + file + ".fm`.");
         process.exit();
       }
-      var defs = (await fm.lang.parse(file, code)).defs;
+      var defs = (await fm.lang.parse(file, code, false, loader)).defs;
 
       var nams = [file + "/" + name];
       if (name === "@") {
@@ -165,7 +178,16 @@ async function upload(file, global_path = {}) {
           }
           try {
             if (defs[nams[i]]) {
-              var term = fm.exec(nams[i], defs, mode, opts, stats);
+
+              var term
+                = args.d ? fm.exec.debug_reduce(nams[i], defs, opts)
+                : args.o ? fm.exec.optimal_reduce(nams[i], defs, {...opts, stats})
+                : args.O ? fm.exec.optimal_reduce(nams[i], defs, {...opts, stats})
+                : args.j ? fm.exec.beta_reduce(nams[i], defs, opts)
+                : args.t ? fm.exec.type(nams[i], defs, opts)
+                : args[0] ? (args.X ? term : fm.lang.erase(term))
+                : fm.exec.debug_reduce(nams[i], defs, opts);
+
               console.log(init + fm.lang.show(term, [], {full_refs: !!args.f}));
             } else {
               console.log(init + "Definition not found: " + nams[i]);
@@ -178,7 +200,7 @@ async function upload(file, global_path = {}) {
               //console.log(e.toString());
             }
           }
-          if (args.p || (mode.slice(0,3) === "OPT" && !args.h)) {
+          if (args.p || ((args.o || args.O) && !args.h)) {
             console.log(JSON.stringify(stats));
           }
         }


### PR DESCRIPTION
This commit squashes all the commits that were supposed to be on
consistency-fix but weren't.

This includes the commits named:

- Revert "Revert "simplify fm-lang by parametrizing the file loader""
- fix: remake the local import detection on the uploader
- fix: use of instead of in
- feat: exec helper module with json call
- fix: call to exec
- fix: redeclaration of variable term in subst