### PR TITLE
feat: new forall client

### DIFF
--- a/src/fm-lang.js
+++ b/src/fm-lang.js
@@ -30,7 +30,7 @@ const version = require("./../package.json").version;
 const to_net = require("./fm-to-net.js");
 const to_js = require("./fm-to-js.js");
 const net = require("./fm-net.js");
-const {load_file} = require("./forall.js");
+const {load_file} = require("./forall/loaders.js");
 const {marked_code, random_excuse} = require("./fm-error.js");
 
 // :::::::::::::::::::::
@@ -650,7 +650,7 @@ const parse = async (code, opts, root = true, loaded = {}) => {
     if (!defs[name+"b"]) {
       var term = base_ref("be");
       for (var i = 0; i < name.length; ++i) {
-        var term = App(base_ref(name[name.length - i - 1] === "0" ? "b0" : "b1"), term, false); 
+        var term = App(base_ref(name[name.length - i - 1] === "0" ? "b0" : "b1"), term, false);
       }
       define(name+"b", term);
     }
@@ -662,7 +662,7 @@ const parse = async (code, opts, root = true, loaded = {}) => {
     if (!defs[name+"B"]) {
       var term = base_ref("ibe");
       for (var i = 0; i < name.length; ++i) {
-        var term = App(base_ref(name[name.length - i - 1] === "0" ? "ib0" : "ib1"), term, false); 
+        var term = App(base_ref(name[name.length - i - 1] === "0" ? "ib0" : "ib1"), term, false);
       }
       define(name+"B", term);
     }
@@ -794,7 +794,7 @@ const parse = async (code, opts, root = true, loaded = {}) => {
         term = Var(nams.length - i - 1, loc(name.length));
         term[1].__name = name;
         if (tokens) tokens[tokens.length - 1][0] = "var";
-      // Inline binary operator 
+      // Inline binary operator
       } else if (is_native_op[name]) {
           term = Lam("x", Num(), Lam("y", Num(), Op2(name, Var(1), Var(0)), false), false);
           if (tokens) tokens[tokens.length - 1][0] = "nop";

--- a/src/forall/index.js
+++ b/src/forall/index.js
@@ -1,0 +1,23 @@
+// This module is responsible for loading and publishing files from the Forall repository
+// For now this is using the deprecated moonad.org/api repository, but will be updated to the newer
+// Forall API once the service is deployed and ready to be used.
+//
+// This also exports a few "loader decorators" to enable caching depending on the environment
+
+const utils = require("./utils")
+const saver = require("./saver")
+const loaders = require("./loaders")
+const decorators = require("./loader_decorators")
+
+module.exports = {
+  parse_name: utils.parse_name,
+  format_name: utils.format_name,
+  checker: saver.checker,
+  load_file_metadata: loaders.load_file_metadata,
+  load_file_parents: loaders.load_file_parents,
+  load_file: loaders.load_file,
+  save_file: saver.save_file,
+  with_file_system_cache: decorators.with_file_system_cache,
+  with_local_files: decorators.with_local_files,
+  with_local_storage_cache: decorators.with_local_storage_cache,
+}

--- a/src/forall/loaders.js
+++ b/src/forall/loaders.js
@@ -1,0 +1,62 @@
+// All side-effect free functions that interact with forall.
+
+const {parse_name, urls, xhr} = require("./utils");
+
+/**
+ * @typedef FileReference
+ * @type {object}
+ * @property {string} name
+ * @property {string} version
+ */
+
+/**
+ * @typedef FileMetadata
+ * @type {object}
+ * @property {FileReference} reference
+ * @property {FileReference[]} deep_imports
+ * @property {FileReference[]} imported_by
+ */
+
+/** Loads the content of a file asynchornously
+ * @param {string|FileReference} file
+ * @returns {Promise<string>}
+ */
+async function load_file(file) {
+  const file_reference = typeof file === "string" ? parse_name(file) : file;
+  if(!file_reference) throw "Invalid file name";
+  try {
+    return (await xhr(urls.get_file(file_reference))).data;
+  } catch (response) {
+    if(response.statusCode === 404) throw "File not found on Forall";
+    throw response.data || "Undefined error while getting file from forall";
+  }
+}
+
+/** Receives a file name or reference and returns a list of parents for that file
+ * @param {string|FileReference} file
+ * @returns {Promise<FileReference[]>}
+ */
+async function load_file_parents(file) {
+  return (await load_file_metadata(file)).imported_by
+}
+
+/** Receives a file name or reference and returns all metadata
+ * @param {string|FileReference} file
+ * @returns {Promise<FileMetadata>}
+ */
+async function load_file_metadata(file) {
+  const file_reference = typeof file === "string" ? parse_name(file) : file;
+  if(!file_reference) throw "Invalid file name";
+  try {
+    return (await xhr(urls.get_file_metadata(file_reference), {json: true})).data
+  } catch (response) {
+    if(response.statusCode === 404) throw "File not found on Forall";
+    throw response.data || "Undefined error while getting file from forall";
+  }
+}
+
+module.exports = {
+  load_file,
+  load_file_metadata,
+  load_file_parents
+}

--- a/src/forall/saver.js
+++ b/src/forall/saver.js
@@ -65,7 +65,7 @@ function checker(loader = load_file) {
 
   const typechecks = (name, defs) => {
     try {
-      lang.typecheck(defs[name], null, {no_logs: true, defs})
+      lang.typecheck(name, null, {no_logs: true, defs})
       return true;
     } catch(e) {
       return false;

--- a/src/forall/saver.js
+++ b/src/forall/saver.js
@@ -1,0 +1,102 @@
+// Saves files to forall
+
+const lang = require("../fm-lang.js")
+const {load_file} = require("./loaders")
+const {urls, format_name, xhr} = require("./utils")
+
+/**
+ * @typedef FileReference
+ * @type {object}
+ * @property {string} name
+ * @property {string} version
+ */
+
+/**
+ * @typedef SaveFileOpts
+ * @type {object}
+ * @property {Function} checker - A function that checks for forall constraints with signature
+ * string -> Promise<boolean>. Defaults to `checker()`
+ */
+
+/**
+ * Saves a file to Forall and checks for collision. Raises an error if a collision occurs.
+ * @param {string} name - The name of the file
+ * @param {string} code - The code to be saved
+ * @param {SaveFileOpts} opts - Options for saving the file
+ * @returns {FileReference} The file reference to the saved file, if succeeded.
+ */
+async function save_file(name, code, opts = {}) {
+  const check_fn = opts.checker || checker()
+
+  if(!(await check_fn(code))) throw "Code does not pass forall code"
+
+  let file_reference
+  try {
+    const {data} = await xhr(urls.create_file,{
+      method: "POST",
+      json: true,
+      body: {name, code}
+    })
+
+    file_reference = data
+  } catch({data}) {
+    // TODO: Handle better the return of file save
+    throw data
+  }
+
+  const saved_code = await poll_for(async () => await load_file(file_reference), 100, 50);
+  if(saved_code != code) throw `Version collision while saving ${format_name(file_reference)}.`;
+  return file_reference;
+}
+
+/**
+ * Builds a file checker that complies to forall requirements.
+ * @callback loader
+ * @returns {Function} A function that returns a `Promise<boolean>`.
+ */
+function checker(loader = load_file) {
+  const file = "local";
+  const is_local_def = (name) => name.indexOf(file) === 0;
+  const local_def_names = (defs) => Object.keys(defs).filter(is_local_def);
+  const all_typechecks = (names, defs) => {
+    const incorrect = names.filter((name) => !typechecks(name, defs))
+    return incorrect.length === 0
+  }
+
+  const typechecks = (name, defs) => {
+    try {
+      lang.typecheck(defs[name], null, {no_logs: true, defs})
+      return true;
+    } catch(e) {
+      return false;
+    }
+  }
+
+  return async function check_requirements(code){
+    try {
+      const { defs } = await lang.parse(code, {file, loader})
+
+      return all_typechecks(local_def_names(defs), defs);
+    } catch(e) {
+      return false
+    }
+  }
+}
+
+module.exports = {
+  save_file,
+  checker
+}
+
+
+async function poll_for(fn, interval, tries){
+  try {
+    return await fn()
+  } catch(e) {
+    if(tries && tries <= 0) throw e;
+    await delay(interval);
+    return poll_for(fn, interval, tries-1);
+  }
+}
+
+const delay = (timeout) => new Promise((resolve) => setTimeout(resolve, timeout))

--- a/src/forall/utils.js
+++ b/src/forall/utils.js
@@ -1,0 +1,67 @@
+// Shared utils for forall modules
+
+const request = require('xhr-request')
+
+/**
+ * @typedef FileReference
+ * @type {object}
+ * @property {string} name
+ * @property {string} version
+ */
+
+/**
+ * Converts a name as in Formality (formatted as {name}#{version}) to a structured json
+ * @param {string} name
+ * @returns {FileReference|undefined} The parsed parts of a name
+ */
+function parse_name(name){
+  const match = name.match(name_regexp)
+  if(match) {
+    return {name: match[1], version: match[2]}
+  }
+}
+
+/**
+ * Formats a name from a file reference
+ * @param {FileReference} file_reference
+ * @returns {string} The string formatted for Formality, such that if parsed with `parse_name` will
+ * return the same structure.
+ */
+function format_name({name, version}){
+  return `${name}#${version}`
+}
+
+// TODO: Change to files.forall.fm. For now Digital Ocean is behaving weirdly, so we are getting
+// the file from Spaces Origin instead of getting it from the CDN
+const cdn_url = "https://forall.nyc3.digitaloceanspaces.com"
+const api_url = "https://forall.fm/api"
+
+const urls = {
+  create_file: `${api_url}/files/`,
+  get_file: ({name, version}) => `${cdn_url}/${name}/${version}.fm`,
+  get_file_metadata: ({name, version}) => `${api_url}/files/${name}/${version}`
+}
+
+const xhr = function (url, options) {
+  return new Promise(function (resolve, reject) {
+    request(url, options, function (err, data, response) {
+      if (err) reject(err);
+      else if(response.statusCode >= 400) reject({...response, data})
+      else resolve({...response, data});
+    });
+  });
+};
+
+module.exports = {
+  parse_name,
+  format_name,
+  urls,
+  xhr
+}
+
+const name_regexp = (() => {
+  const chars = "a-zA-Z0-9_\\-";
+  const dotted = `[${chars}]+[${chars}\\.]*`;
+  const hash = `[${chars}]+`;
+  return new RegExp(`(${dotted})#(${hash})`);
+})();

--- a/src/main.js
+++ b/src/main.js
@@ -74,9 +74,6 @@ const loader = fm.forall.with_local_files(base_loader)
 // Create a forall checker that uses file system cache when downloading files for checking uploads.
 const forall_checker = fm.forall.checker(base_loader)
 
-// Creates a local checker to check nested files before uploading
-const local_checker = fm.forall.checker(loader)
-
 async function local_imports_or_exit(file, code) {
   try {
     const {open_imports} = await fm.lang.parse(code, {file, tokenify: false, loader});
@@ -90,11 +87,6 @@ async function local_imports_or_exit(file, code) {
 async function upload(file, global_path = {}) {
   if (!global_path[file]) {
     var code = fs.readFileSync(file + ".fm", "utf8");
-
-    if(!(await local_checker(code))){
-      console.error(`${file} does not pass forall requirements.`)
-      throw "Forall Check failed"
-    }
 
     const local_imports = await local_imports_or_exit(file, code);
 


### PR DESCRIPTION
This implements the new Forall client (to get and upload files from/to `forall.fm`)

It is working OK but with a few caveats:

- The Forall CDN (`files.forall.fm` doesn't seem to be working properly, so this is getting directly from the origin, which means is not distributed like a CDN, I'll check why this is happening and fix later)
- It is really inefficient (when publishing) as of right now, but it is possible to optimize it later

About the inefficiency, the problem is that there is a lot of duplicate work.
For example, for one file, it is parsed twice: one for getting the tokens so it can replace any local imports (by uploading them and replacing the code) and another time to typecheck it.
Also, since if a file depends on another, that another also has to be parsed when parsing the one that depends on it.
So, for example, if we have a dependency graph like `A -> B -> C -> D`, then `A` will be parsed 2 times, `B` will be parsed 4 times, `C` will be parsed 6 times and `D` will be parsed 8 times.
To solve that, all we need to do is to cache the parsed result of a file and pass that to the parsing function. But for not, this is left to a further PR.