### PR TITLE
Fix type parameter inference example?

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -796,7 +796,7 @@ Or, if the type can be inferred:
 ```haskell
 import Base#
 
-main : List(Nat)
+main : List(?)
   [1n, 2n, 3n]
 ```
 


### PR DESCRIPTION
Is this right?
It didn't make sense for the two examples to be the same, and I found this which typechecks and runs correctly