### PR TITLE
Documentation Improvements

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -42,7 +42,7 @@ For comparison, in Agda the definition would be:
 
 ```agda
 data Vec (A : Set) : (len : Nat) -> Set where
-  nil : Vec A len
+  nil : Vec A zero
   cons : (n : Nat) -> (x : A) -> (xs : Vec A n) -> Vec A (succ n)
 ```
 A few differences: in Agda, you separate parameters and indices with a : . In Formality, you write parameters inside <> and indices after the ~ . In Agda, you need -> Set on the first line. In Formality, no. In Agda, you write the fields with (a : A) -> (b : B) -> ... . In Formality, you write with (a: A, b: B) . In Agda, you need to write the return type of each constructor. In Formality, we omit the return type. Problem is, that only works for non-indexed datatypes; for indexed datatypes, you *need* to write the indices. So, to do that while also omitting the return type, we use ~ to configure the index on each case.
@@ -116,5 +116,4 @@ Monadic effects (todo - explain).
 Yes! It's an interesting tradeoff, and we've considered them, along with several other
 strategies. Moonad's treatment of imports is still in the works - if you have
 an opinion, come share it on Telegram.
-
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,8 +1,8 @@
 # Frequently Asked Questions
 (or, asked at least once anyway 😃)
 
-Not satisfied by the answer? Don't see your question? Swing by our
-[on Telegram](https://t.me/formality_lang) and we'd be happy to help.
+Not satisfied by the answer? Don't see your question? Swing by
+[Telegram](https://t.me/formality_lang) and we'd be happy to help.
 
 ## Table of Contents
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,120 @@
+# Frequently Asked Questions
+(or, asked at least once anyway 😃)
+
+Not satisfied by the answer? Don't see your question? Swing by our
+[on Telegram](https://t.me/formality_lang) and we'd be happy to help.
+
+## Table of Contents
+
+Questions are in no particular order, but are loosely grouped
+by category.
+
+- [Frequently Asked Questions](#frequently-asked-questions)
+  - [Table of Contents](#table-of-contents)
+  - [Formality Features](#formality-features)
+    - [Indexed Data Types, or "What's that funny '~'"?](#indexed-data-types-or-whats-that-funny-)
+    - [Does Formality compile to native datatypes by name or definition?](#does-formality-compile-to-native-datatypes-by-name-or-definition)
+    - [How do I implement interfaces/typeclasses/traits?](#how-do-i-implement-interfacestypeclassestraits)
+    - [Is Formality Consistent?](#is-formality-consistent)
+    - [Can I have axioms?](#can-i-have-axioms)
+    - [What are the different parts of Formality?](#what-are-the-different-parts-of-formality)
+    - [What's the difference between Formality-Core and EA-TT?](#whats-the-difference-between-formality-core-and-ea-tt)
+    - [Does Formality use the Optimal Calculus (Ultimate Calculus), or does it use INets?](#does-formality-use-the-optimal-calculus-ultimate-calculus-or-does-it-use-inets)
+  - [Formality Concepts](#formality-concepts)
+    - [What's the difference between Bool.true and truth?](#whats-the-difference-between-booltrue-and-truth)
+    - [What is Unit? What is Empty? What does this have to do with truth and falsity?](#what-is-unit-what-is-empty-what-does-this-have-to-do-with-truth-and-falsity)
+    - [If Formality doesn't have side-effects, how do I do IO?](#if-formality-doesnt-have-side-effects-how-do-i-do-io)
+  - [Moonad](#moonad)
+    - [Have you heard of Unison's hash-based imports?](#have-you-heard-of-unisons-hash-based-imports)
+
+## Formality Features
+### Indexed Data Types, or "What's that funny '~'"?
+The `~` operator allows you to index a datatype. For example, 
+consider the definition of Vector, a List with a statically
+known length:
+```
+T Vec <A: Type>                 ~ (len: Nat)
+| nil                           ~ (zero);
+| cons(n:Nat, x:A, xs:Vec(A,n)) ~ (succ(n));
+```
+
+For comparison, in Agda the definition would be:
+
+```agda
+data Vec (A : Set) : (len : Nat) -> Set where
+  nil : Vec A len
+  cons : (n : Nat) -> (x : A) -> (xs : Vec A n) -> Vec A (succ n)
+```
+A few differences: in Agda, you separate parameters and indices with a : . In Formality, you write parameters inside <> and indices after the ~ . In Agda, you need -> Set on the first line. In Formality, no. In Agda, you write the fields with (a : A) -> (b : B) -> ... . In Formality, you write with (a: A, b: B) . In Agda, you need to write the return type of each constructor. In Formality, we omit the return type. Problem is, that only works for non-indexed datatypes; for indexed datatypes, you *need* to write the indices. So, to do that while also omitting the return type, we use ~ to configure the index on each case.
+
+### Does Formality compile to native datatypes by name or definition?
+
+The Javascript backend for Formality automatically compiles `Bool`'s
+`String`'s, `Nat`'s, etc. to native Javascript booleans, strings, BigIntegers, etc.
+This produces large performance gains over lambda-encoded data structures.
+Formality uses the name of the type to do this - i.e, `Nat` will always be compiled
+to BigIntegers, but an identical definition with a different name won't.
+
+### How do I implement interfaces/typeclasses/traits?
+
+A good example to emulate is [Moonad's definition for monad](https://github.com/moonad/Moonad/blob/master/lib/Monad.fm). The basic idea is to define a seperate type that
+takes in a type as an erased argument, and whose type constructor takes in the methods
+defined on that "typeclass/trait". Then you can define "methods" on the "typeclass"
+that just call the implementation supplied by the user.
+
+(note: this will change if and when Formality has functional extensionality)
+
+### Is Formality Consistent?
+
+No, and that's by design. Here's a snippet from a recent conversation on it:
+
+> ...I concluded making core consistent was a software engineering mistake, since it forces everyone into a specific termination discipline, and different people might want to work on different terminating subsets. For example you might have structural recursion and be Coq/Agda-like. Or you might have elementary duplications and be interaction-net friendly. Or you may just be writing web apps and not care about termination.
+
+### Can I have axioms?
+
+Definitely! It's as easy as recursion:
+
+```
+axiom: A
+    axiom
+```
+
+This obviously wouldn't pass the termination checker, is still valid Formality code.
+
+### What are the different parts of Formality?
+- Formality-Lang
+- Formality-Core
+- The termination checker (to be implemented)
+- A backend (Javascript, Haskell, EVM, etc.)
+- Moonad
+
+### What's the difference between Formality-Core and EA-TT?
+- FormalityCore is a superset of EA-TT.
+- FormalityCore with boxes is EA-TT. This subset has affinity and termination, and compiles to the super-fast inets.
+
+### Does Formality use the Optimal Calculus (Ultimate Calculus), or does it use INets?
+
+## Formality Concepts
+
+### What's the difference between Bool.true and truth?
+
+This is subtle, but near to the heart of Formality and worth mulling over:
+check out Victor Maia's [gist on the subject](https://gist.github.com/MaiaVictor/6f0ad6665bcefc6cd2997538e7c6c185).
+
+
+### What is Unit? What is Empty? What does this have to do with truth and falsity?
+Check out the previous question! 
+
+### If Formality doesn't have side-effects, how do I do IO?
+
+Monadic effects (todo - explain).
+
+## Moonad
+
+### Have you heard of Unison's hash-based imports?
+
+Yes! It's an interesting tradeoff, and we've considered them, along with several other
+strategies. Moonad's treatment of imports is still in the works - if you have
+an opinion, come share it on Telegram.
+
+

--- a/FMC_SPECIFICATION.md
+++ b/FMC_SPECIFICATION.md
@@ -14,25 +14,27 @@ and used to reason and prove theorems about itself.
 
 ## Table of Contents
 
-- [0. Motivation](#0-motivation)
-  - [0.0. Modern proof assistants are complex](#00-modern-proof-asistants-are-complex)
-  - [0.1. A simpler alternative](#01-a-simpler-alternative)
-  - [0.2. The cost of consistency](#02-the-cost-of-consistency)
-  - [0.3. Formality's take on consistency](#03-formalitys-take-on-consistency)
-  - [0.4. Efficiency is misunderstood](#04-efficiency-is-misunderstood)
-  - [0.5. Enhancing programmers productivity](#05-enhancing-programmers-productivity)
-- [1. Specification](#1-specification)
-  - [1.0. Terms](#10-terms)
-  - [1.1. Syntax](#11-syntax)
-  - [1.2. Evaluation](#12-evaluation)
-  - [1.3. Equality](#13-equality)
-  - [1.4. Types](#14-types)
-- [2. Formalization](#2-formalization)
-  - [2.0. Terms](#10-terms)
-  - [2.1. Syntax](#11-syntax)
-  - [2.2. Evaluation](#12-evaluation)
-  - [2.3. Equality](#13-equality)
-  - [2.4. Types](#14-types)
+- [Formality](#formality)
+  - [Table of Contents](#table-of-contents)
+  - [0. Motivation](#0-motivation)
+    - [0.0. Modern proof asistants are complex](#00-modern-proof-asistants-are-complex)
+    - [0.1. A simpler alternative](#01-a-simpler-alternative)
+    - [0.2. The cost of consistency](#02-the-cost-of-consistency)
+    - [0.3. Formality's take on consistency](#03-formalitys-take-on-consistency)
+    - [0.4. Efficiency is misunderstood](#04-efficiency-is-misunderstood)
+    - [0.5. Enhancing programmers productivity](#05-enhancing-programmers-productivity)
+  - [1. Specification](#1-specification)
+    - [1.0. Terms](#10-terms)
+    - [1.1. Syntax](#11-syntax)
+    - [1.2. Evaluation](#12-evaluation)
+    - [1.3. Equality](#13-equality)
+    - [1.4. Types](#14-types)
+  - [2. Formalization](#2-formalization)
+    - [2.0. Terms](#20-terms)
+    - [2.1. Syntax](#21-syntax)
+    - [2.2. Evaluation](#22-evaluation)
+    - [2.3. Equality](#23-equality)
+    - [2.4. Types](#24-types)
 
 
 ## 0. Motivation
@@ -65,7 +67,7 @@ Under that perspective, one may be interested on the Calculus of Constructions
 (CoC), a small type theory that easily fits 1000 lines of code in a modern
 programming language. Sadly, that and similar languages aren't capable of
 deriving mathematical induction, an important proof technique without which any
-non-trivial theorem isn't proveable. Moreover, it isn't capable of expressing
+non-trivial theorem isn't provable. Moreover, it isn't capable of expressing
 efficient (constant space and time) pattern-matching, without which functional
 programming isn't viable. The usual solution to both problems is to supplement
 CoC with a native datatype system, but this results in the complexity explosion
@@ -83,7 +85,7 @@ that solution is that providing a semantics and, thus, proving the consistency
 of the resulting system becomes extremely hard.
 
 Aaron Stump moved on from self types towards a very similar solution based on
-dependent intersections. The idea is theat, instead of relying on mutual
+dependent intersections. The idea is that, instead of relying on mutual
 recursion, inductive datatypes can refer to themselves in simplified, erased
 forms. This results in a comparably small language that is much easier to
 provide a semantics for, which Aaron Stump called Cedille-Core. In exchange,
@@ -99,7 +101,7 @@ Formality has a different take on consistency that comes from the realization
 that consistency isn't hard, it is complex. The reason is that consistency
 demands termination, which, due to the halting problem, simply can't be
 implemented without either forbidding a program that is "important to someone",
-or by making the language extremelly more complex.
+or by making the language extremely more complex.
 
 For example, there is a very easy way to make a proof language consistent:
 disable recursion and non-affine lambdas. This would be sound even with
@@ -152,7 +154,7 @@ doing so in Haskell, making it very flexible and powerful.
 
 As a proof assistant, it can still be used to aid someone's theorem proving
 tasks by automating type-checking. Then, if one is interested in making sure a
-proof isn't paradoxal, then he/she simply uses a separate termination checker.
+proof isn't paradoxical, then he/she simply uses a separate termination checker.
 Ultimately, the result is the same, with the added benefit that one may combine
 programs that wouldn't be allowed in traditional proof assistants into a proof
 that turns out to be valid in some context. Not only that, we may pick different
@@ -404,7 +406,7 @@ after substitution, it accidentally refers to the inner lambda. This must be
 somehow avoided.
 
 Formality-Core doesn't define any evaluation order. It could be evaluated
-strictly as in JavaScripy and Python, lazily as in Haskell, or optimally through
+strictly as in JavaScript and Python, lazily as in Haskell, or optimally through
 interaction nets. The reference implementation uses high-order abstract syntax
 (HOAS). That is, in the syntax tree, `Var` variants can be replaced by
 host-language variables bound in the respective `Lam`, `All` or `Let`. For

--- a/OLD_DOCUMENTATION.md
+++ b/OLD_DOCUMENTATION.md
@@ -1,36 +1,58 @@
 Table of contents
 =================
 
+- [Table of contents](#table-of-contents)
 - [Motivation](#motivation)
+  - [An accessible syntax](#an-accessible-syntax)
+  - [Fast and portable "by design"](#fast-and-portable-by-design)
+  - [An elegant underlying Type Theory](#an-elegant-underlying-type-theory)
+  - [An optimal high-order evaluator](#an-optimal-high-order-evaluator)
 - [Installation](#installation)
 - [Commands](#commands)
 - [Introduction](#introduction)
 - [Principles](#principles)
+  - [Type-Checking](#type-checking)
+  - [Compilation](#compilation)
+    - [Ethereum](#ethereum)
+  - [Effects](#effects)
 - [Primitives](#primitives)
-    - [Let](#let)
-    - [Lambda](#lambda)
-    - [Number](#number)
-    - [Self](#self)
-    - [Annotation](#annotation)
-    - [Hole](#hole)
-    - [Log](#log)
-    - [Import](#import)
+  - [Type](#type)
+  - [Lambda](#lambda)
+  - [Number](#number)
+  - [Let](#let)
+  - [Self](#self)
+  - [Annotation](#annotation)
+  - [Hole](#hole)
+  - [Log](#log)
+  - [Import](#import)
 - [Datatypes](#datatypes)
-    - [Basics](#basics)
-    - [Fields](#fields)
-    - [Move](#move)
-    - [Recursion](#recursion)
-    - [Polymorphism](#polymorphism)
-    - [Indices](#indices)
-    - [Motive](#motive)
-    - [Encoding](#encoding)
-- [Advanced](#advanced)
-    - [Proofs](#proofs)
+  - [Basics](#basics)
+  - [Fields](#fields)
+  - [Move](#move)
+  - [Recursion](#recursion)
+  - [Polymorphism](#polymorphism)
+  - [Indices](#indices)
+  - [Motive](#motive)
+      - [Example: proving equalities](#example-proving-equalities)
+      - [Example: proving absurds](#example-proving-absurds)
+      - [Example: avoiding unreachable branches](#example-avoiding-unreachable-branches)
+  - [Encoding](#encoding)
+- [Proofs](#proofs)
 - [Theory](#theory)
-    - [Formality Core](#formality-core)
-    - [Formality Calculus](#formality-calculus)
-    - [Formality Net](#formality-net)
-    - [Compilation](#net-compilation)
+  - [Formality Core](#formality-core)
+  - [Formality Calculus](#formality-calculus)
+  - [Formality Net](#formality-net)
+      - [Rewrite rules](#rewrite-rules)
+      - [Erasure](#erasure)
+      - [Substitution](#substitution)
+      - [Duplication](#duplication)
+      - [If-Then-Else](#if-then-else)
+      - [Num-Operation](#num-operation)
+      - [Implementation](#implementation)
+      - [Rewrites](#rewrites)
+      - [Strict evaluation](#strict-evaluation)
+      - [Lazy evaluation](#lazy-evaluation)
+  - [Net-Compilation](#net-compilation)
 
 Motivation
 ==========
@@ -183,7 +205,7 @@ Docs.welcome: IO(Unit)
 But what are monads? Simple, monads are just... things that you must not worry
 about for now. See, it is tempting to teach monads in the beginning of
 functional programming materials, but we believe that is the wrong approach.
-Instead, we must focus on the building blocks, the foundamental principles that
+Instead, we must focus on the building blocks, the fundamental principles that
 eventually lead to understanding what those are. So that's what we are going to
 do. Forget about IO, printing and let's learn Formality from principles. Ready?
 
@@ -328,7 +350,7 @@ explored later.
 Compilation
 -----------
 
-Since Formality's core language is extremelly simple - it is
+Since Formality's core language is extremely simple - it is
 just the λ-calculus with numbers - it is very easy to
 compile it to multiple targets. For example, let's compile
 the following library to JavaScript:

--- a/README.md
+++ b/README.md
@@ -268,4 +268,9 @@ the thing!
   want most, send us a PR or let us know [on Telegram](https://t.me/formality_lang). Formality
   is a vast and rich frontier: who knows what dependently-typed glories await the intrepid?
 
-[Insert one last quote here as an outro. We need some Terry Pratchet or sci-fi.]
+> “To every man, in his acquaintance with a new art, there comes a moment when that which before
+> was meaningless first lifts, as it were, one corner of the curtain that hides its mystery,
+> and reveals, in a burst of delight which later and fuller understanding can hardly ever equal,
+> one glimpse of the indefinite possibilities within.”
+>
+> *Out of the Silent Planet*, C.S. Lewis

--- a/README.md
+++ b/README.md
@@ -8,18 +8,26 @@ An lightweight proof-gramming language. It aims to be:
 
 - **Portable:** the entire language desugars to a 500 lines core type-theory.
 
-Explore our ecossystem at [moonad.org](http://moonad.org) and come hang out with us [on Telegram](https://t.me/formality_lang).
+Explore our ecosystem at [moonad.org](http://moonad.org) and come hang out with us [on Telegram](https://t.me/formality_lang).
 
 Table of contents
 =================
 
+- [Table of contents](#table-of-contents)
 - [Motivation](#motivation)
 - [Examples](#examples)
 - [Installation](#installation)
 - [Commands](#commands)
 - [Introduction](#introduction)
 - [Principles](#principles)
-- [Booleans](#booleans)
+- [Formality Basics](#formality-basics)
+  - [The Bool Type](#the-bool-type)
+  - [A Bool function](#a-bool-function)
+    - [Testing](#testing)
+  - [A Bool theorem](#a-bool-theorem)
+  - [The Nat Type](#the-nat-type)
+  - [A Nat function](#a-nat-function)
+  - [A Nat theorem](#a-nat-theorem)
 
 Motivation
 ==========
@@ -277,7 +285,7 @@ type `A`, for any value `x : A`, a proof that `x == x`. To make sure this is
 correct, type `fm`. This will make Formality type-check all definitions on the
 current directory and let you know if there is any error.
 
-Let's now prove that `not(not(a)) == a`. Since this involes an expression, we
+Let's now prove that `not(not(a)) == a`. Since this involves an expression, we
 need a function:
 
 ```c

--- a/README.md
+++ b/README.md
@@ -19,15 +19,14 @@ Table of contents
 - [Installation](#installation)
 - [Commands](#commands)
 - [Introduction](#introduction)
-- [Principles](#principles)
-- [Formality Basics](#formality-basics)
-  - [The Bool Type](#the-bool-type)
-  - [A Bool function](#a-bool-function)
-    - [Testing](#testing)
-  - [A Bool theorem](#a-bool-theorem)
-  - [The Nat Type](#the-nat-type)
-  - [A Nat function](#a-nat-function)
-  - [A Nat theorem](#a-nat-theorem)
+    - [📦 Dependencies](#-dependencies)
+    - [✔️ Type Checking](#️-type-checking)
+    - [📜 Compile to Javascript](#-compile-to-javascript)
+    - [🚀 Run](#-run)
+    - [💡 Datatypes, Functions, and Proofs](#-datatypes-functions-and-proofs)
+- [Learning More](#learning-more)
+- [Roadmap](#roadmap)
+- [Contributing](#contributing)
 
 Motivation
 ==========
@@ -102,14 +101,6 @@ Installation
 
 2. Install the language with `npm i -g formality-lang`.
 
-3. Clone the Moonad libraries: `git clone http://github.com/moonad/moonad`.
-
-4. Enter the directory with `cd moonad/lib`.
-
-5. Type `fm`.
-
-This will type-check every `.fm` file on the `moonad` directory.
-
 Commands
 ========
 
@@ -134,306 +125,139 @@ The commands below load all `.fmc` files in the current directory.
 Introduction
 ============
 
-This is the "Hello, World!" in Formality:
+Let's write "Hello, World!" in Formality!
+
+First, create a new file somewhere called `Hello.fm` and add this text
+to it:
 
 ```javascript
-main: IO(Unit)
+Hello.world: IO(Unit)
   IO.print("Hello, world!")
 ```
 
-To run it, save this file `main.fm` and type `fmio main`. This will download
-some dependencies, compile it to JavaScript and run, printing `Hello, world` to
-the console. Here, [`IO.print`](http://moonad.org/p/0x0000000000000047) is
-just a definition on [moonad.org](http://moonad.org). In Formality, there is no
-such a thing as packages. Instead, once a definition is posted on Moonad, it is
-globally available for all other users. That's because, by philosophy, Formality
-is a very small language that is extended by its own users every time some code
-is posted on Moonad.
+The first expression `Hello.world` defines a function called `world` in
+the `Hello` namespace (all definitions must be namespaced with the same
+name as the file they're found in).
+The type of this expression is `IO(Unit)` (more about that later).
 
-You can also type-check that file by running `fm main`, and you can compile it
-to JavaScript, run `fmjs main`. The generated code is highly optimized and uses
-native structures whenever possible.
+Let's try running our little program. On a command line, run:
 
-For a bigger example, run this with `fmio main`:
+```
+fmio Hello.world
+```
+
+This will download the necessary dependencies, type check the new definitions,
+compile everything to Javascript, and run, printing `Hello, world` in the
+console. Let's look at each of these steps in a little more detail:
+
+### 📦 Dependencies
+Formality will discover it doesn't have definitions for `IO(Unit)`
+and `IO.print`, and wil download them from [moonad.org](moonad.org).
+Formality doesn't have a notion of packages or a central package
+repository. Instead, users can post definitions to Moonad, making
+them globally available for all other users, essentially extending the 
+language itself. This is Formality's philosophy on pretty much everything:
+keep the language as small and diamond-perfect as possible, but make it 
+easy to extend and share.
+
+### ✔️ Type Checking
+With all the definitions in place, Formality will sure
+every definition fulfills its type. This process is *much* more powerful
+in Formality than in traditional languages: as in proof assistants like
+Coq and Agda, types can express deep properties about your programs, and
+Formality will make sure they hold (more about this later in the section on
+[theorem Proving](./THEOREM_PROVING_TUTORIAL.md)).
+
+### 📜 Compile to Javascript
+
+Formality programs compile to fast, tiny Javascript modules. The output is
+quite clean too! Check it out yourself by running:
+
+  ```
+  fm2js Hello.world
+  ```
+Javascript is currently the default runtime for Formality, and the one we recommend
+for learning the language. But, as mentioned, Haskell and EVM runtimes exist. In
+fact, writing a new runtime in your favorite language is simple and a nice weekend project - check out our tutorial [TODO - tutorial is a work in progress; in the
+meantime, everything you'd need to implement is in [this file](https://github.com/moonad/Formality/blob/master/javascript/FormalityCore.js)]!
+
+### 🚀 Run
+The `fm` command will execute the compiled Javascript, printing
+`Hello, world.` to the console.
+
+For a more interactive example, we could add the following function
+to our `Hello.fm` file:
 
 ```javascript
-main: IO(Unit)
+Hello.greet: IO(Unit)
   do IO {
     var name = IO.prompt("What is your name?");
     IO.print(String.concat("Welcome, ", name));
   }
 ```
 
-Since Formality is a pure functional language, it has no built-in notion of
-side-effects (like printing), but we can still **describe** then: that's what
-the `IO` type does, using monads. But what are monads? Simple, monads are
-just... things that you must not worry about for now. Let's focus on the
-fundamental principles of the language first!
-
-Principles
-==========
-
-Formality programs are just a series of top-level definitions: datatype
-declarations and functions (or proofs). As such, programming in Formality almost
-always consists of the following activity:
-
-1. Specify the data formats that are used in your problem.
-
-2. Program functions that transform those data formats.
-
-3. Propose and prove theorems about those.
-
-Of the steps above, 1 and 2 are very familiar to most developers, but 3 is not.
-If you're not familiar with dependent types and theorem proving, we suggest you
-to check our [theorem proving tutorial](THEOREM_PROVING_TUTORIAL.md) before
-proceeding.
-
-Formality Basics
-================
-
-The Bool Type
--------------
-
-The first type we're going to write is the boolean. It is a type with by two
-values: `true` and `false`. In Formality, we declare it as:
-
-```c
-T Bool
-| true;
-| false;
-```
-
-`T` is a keyword to define a new type. `Bool` is the name of the type, and
-`true` and `false` are its two values, or **constructors**. This statement adds
-`Bool.true : Bool` (Bool.true of type Bool), `Bool.false : Bool` (Bool.false of
-type Bool) and `Bool : Type` (Bool of type Type). The `.` here is just part of
-the names.
-
-A Bool function
----------------
-
-The simplest boolean function is the negation, i.e., one that converts `true` to
-`false` and `false` to `true`. We can implement it by case analysis:
-
-```c
-Bool.not(b: Bool): Bool  // Bool.not receives "b of type Bool" and returns "Bool"
-  case b:                // Inspect the value of b...
-  | false => Bool.false; // If it is true, return false.
-  | true  => Bool.true;  // If it is false, return true.
-```
-
-In Formality, it isn't necessary to write the name of each case. This function
-could be written shortly as:
-
-```c
-Bool.not(b: Bool): Bool
-  case b:
-  | Bool.false;
-  | Bool.true;
-```
-
-Since case-analysis on `Bool` is universally known as `if`, this also works:
-
-```c
-Bool.not(b: Bool): Bool
-  if b then
-    Bool.false
-  else
-    Bool.true
-```
-
-Both are equivalent.
-
-### Testing
-
-There are two ways to test a program. We can use `IO` to print values:
-
-```c
-Docs.bool_test_0: IO(Unit)
-  IO.print(Bool.show(Bool.not(Bool.true)))
-```
-
-Run with `fmcio Docs.bool_test_0`. This requires us to be able to stringify
-those values (here, `Bool.show` is defined on `Bool.fm`). An alternative would
-be to just print the values directly, without `IO`:
-
-```c
-Docs.bool_test_1: Bool
-  Bool.not(Bool.true)
-```
-
-Type `fm Docs.bool_test_0`. This will output `(true) (false) false`, which is
-the internal lambda-encoded representation of `Bool.false` (more on that later).
-A last alternative would be to type `fmcio Docs.bool_test_1`. Since the program
-isn't of type `IO`, it will output the compiled JavaScript representation of
-`Bool.false`. In this case, just `false`, but could be a JS object or function.
-
-A Bool theorem
---------------
-
-Let's first prove that `true == true`. Like on the example on the last section,
-it is just a function call. Here, it is called `Equal.to`:
-
-```c
-Docs.true_is_true: Equal(Bool, Bool.true, Bool.true)
-  Equal.to<Bool, Bool.true>
-```
-
-Here, `Equal.to : (A : Type) -> (x : A) -> Equal(A, x, x)`. It returns, for any
-type `A`, for any value `x : A`, a proof that `x == x`. To make sure this is
-correct, type `fm`. This will make Formality type-check all definitions on the
-current directory and let you know if there is any error.
-
-Let's now prove that `not(not(a)) == a`. Since this involves an expression, we
-need a function:
-
-```c
-Docs.not_not_is_b(b: Bool): Equal(Bool, Bool.not(Bool.not(b)), b)
-  Equal.to<Bool, b>
-```
-
-Sadly, this alone doesn't work. Here is the error outputted by `fm`:
-
-```c
-Found type... Equal(Bool)(b)(b)
-Instead of... Equal(Bool)(Bool.not(Bool.not(b)))(b)
-With context:
-- b : Bool
-On line 20:
-    16| Docs.true_is_true: Equal(Bool, Bool.true, Bool.true)
-    17|   Equal.to<Bool, Bool.true>
-    18|
-    19| Docs.not_not_is_b(b: Bool): Equal(Bool, Bool.not(Bool.not(b)), b)
-    20|   Equal.to<Bool, Bool.true>
-    21|
-    22| //Docs.bool_show: IO(Unit)
-    23|   //IO.print(Bool.show(Bool.true))
-```
-
-That's because `Bool.not(Bool.not(b))` is **not** identical to `b`. To make it
-work, we need a case analysis:
-
-```c
-Docs.not_not_is_b(b: Bool): Equal(Bool, Bool.not(Bool.not(b)), b)
-  case b:
-  | Equal.to<Bool, Bool.true>;
-  | Equal.to<Bool, Bool.false>;
-  : Equal(Bool, Bool.not(Bool.not(b.self)), b.self);
-```
-
-The last line tells Formality the type returned by the case expression, with one
-quirk: we use `b.self` to tell Formality to **specialize** that type using the
-concrete value of `b` inside each branch. On the first branch, `b = Bool.true`,
-so `Equal(Bool, Bool.not(Bool.not(b.self)), b.self)` is specialized to
-`Equal(Bool, Bool.not(Bool.not(Bool.true)), Bool.true)`, which reduces to
-`Equal(Bool, Bool.true, Bool.true)`. This allow us to write
-`Equal.to<Bool, Bool.true>` identical, we can use `Equal.to`. The same
-reasoning goes for the last branch. Once all branches are correctly filled,
-Formality **generalizes** `b.self` to the matched value `b`, causing the whole
-`case` expression to have type `Equal(Bool, Bool.not(Bool.not(b)), b)`. This
-completes our first proof!
-
-The Nat Type
-------------
-
-The second type we're going to write is that of natural numbers, i.e.,
-non-negative integers. It can be written like this:
-
-```c
-T Nat
-| zero;
-| succ(pred: Nat);
-```
-
-In other words, a `Nat` is either `zero`, or the successor of another `Nat`. For
-example, `2` is the successor of the successor of `zero`, and can be written as
-`Nat.succ(Nat.succ(Nat.zero))`. With the `Nat` type, we're able to uniquely
-represent any non-negative integer.
-
-A Nat function
---------------
-
-Let's write the addition on `Nat`:
-
-```c
-Nat.add(n: Nat, m: Nat): Nat
-  case n:
-  | m;
-  | Nat.succ(Nat.add(n.pred, m));
-```
-
-Notice that Formality's `case` expression allows us to access the fields
-contained inside the matched values inside their respective cases, with a
-`value.field` name. That is why we can write `n.pred` inside the second case. It
-is not a field accessor: `n.pred` is the actual name of the variable.
-
-The way `add` works is by recursing on the first argument, adding 1 to the result
-on each recursive call. It can be better explained by an example:
+Try running our new `greet` function at the command line:
 
 ```
-add(succ(succ(succ(zero))), succ(succ(zero)))   // add(3, 2)
-= succ(add(succ(succ(zero)), succ(succ(zero)))) // 1 + add(2, 2)
-= succ(succ(add(succ(zero), succ(succ(zero))))) // 1 + 1 + add(1, 2)
-= succ(succ(succ(add(zero, succ(succ(zero)))))) // 1 + 1 + 1 + add(0, 2)
-= succ(succ(succ(succ(succ(zero)))))            // 1 + 1 + 1 + 2
+fmio Hello.greet
 ```
 
-Since `Nat` is a common type, we can write it with numeric literals, which are
-desugared to `Nat.succ(Nat.succ(...Nat.zero))`. Let's test it by adding
-`123456789 + 987654321`:
+Reading and printing to the console raises an important issue: Formality is
+a language without side-effects - as in languages like Haskell and Elm, all
+functions are completely pure (i.e, cannot read or write mutable state). Rather
+than issuing side-effects directly, the standard library defines datatypes that
+_describe_ the effects, which are then interpreted by the runtime.
 
-```c
-Docs.nat_test: Nat
-  Nat.add(123456789, 987654321)
-```
+### 💡 Datatypes, Functions, and Proofs
 
-Running `fmcio Docs.nat_test` outputs `1111111110n`. That's because Formality
-compiles `Nat` to JavaScript `BigInt`, which is a very fast implementation of
-integers.
+Formality is a general purpose language, capable of everything
+from web apps to 3D games to advanced mathematical proofs.
+But all Formality programs share a common structure that comes
+down to three parts:
 
-A Nat theorem
--------------
+1. Specify the datatypes that describe your problem.
 
-Let's now prove two theorems: `add(0, a) == a` and `add(a, 0) == a`. The first
-one is easy:
+2. Write functions that transform those datatypes.
 
-```c
-Docs.0_plus_a_is_a(a: Nat): Equal(Nat, Nat.add(0, a), a)
-  Equal.to<Nat, a>
-```
+3. Propose and prove theorems about your datatypes and functions.
 
-That's because, due to the way `Nat.add` was written, `Nat.add(0, a)` reduces to
-`a`. This allow us to use `Equal.to` directly. The second theorem is harder,
-though. If we try to prove it like the first, we get the following error:
+Learning More
+=============
 
-```c
-Found type... Equal(Nat)(a)(a)
-Instead of... Equal(Nat)(Nat.add(a)(Nat.zero))(a)
-With context:
-- a : Nat
-On line 32:
-    28| Docs.0_plus_a_is_a(a: Nat): Equal(Nat, Nat.add(0, a), a)
-    29|   Equal.to<Nat, a>
-    30|
-    31| Docs.a_plus_0_is_a(a: Nat): Equal(Nat, Nat.add(a, 0), a)
-    32|   Equal.to<Nat, a>
-    33|
-    34| //Docs.bool_show: IO(Unit)
-    35|   //IO.print(Bool.show(Bool.true))
-```
+New to the notion of proving theorems with programs? Check out [our tutorial](TUTORIAL.md) -
+you'll be proving theorems to the moon and back in no time (throw a little of that moon ore
+our way, eh?).
 
-That's because `Nat.add` matches on the first argument, which, here, is a
-variable, so it gets stuck, not unlike `not(not(b)) == b`. For that reason, we
-must proceed by case analysis:
+Do you dream in Pi types and eat monoids for breakfast? You'll probably want
+to see the [specification](FMC_SPECIFICATION.md) (it's incomplete, but still
+covers a lot of ground).
 
-```c
-Docs.a_plus_0_is_a(a: Nat): Equal(Nat, Nat.add(a, 0), a)
-  case a:
-  | Equal.to<Nat, Nat.zero>;
-  | let ind = Docs.a_plus_0_is_a(a.pred)
-    let app = Equal.apply<Nat, Nat, Nat.add(a.pred, Nat.zero), a.pred, Nat.succ, ind>
-    app;
-  : Equal(Nat, Nat.add(a.self, 0), a.self);
-```
+Questions? Queries? Quagmires? Conundrums? Perhaps we've covered it in the [FAQ](./FAQ.md).
+If not, hop on [on Telegram](https://t.me/formality_lang) and we'll see if we can't
+get to the bottom of it.
 
-... to be continued ...
+Roadmap
+=======
+
+TODO - write roadmap section.
+
+Contributing
+============
+
+Are you as excited about democratizing efficient proofs as we are? Come help us build
+the thing! 
+
+- [Moonad.org](moonad.org) is wide open for contributions. Port your favorite library to
+  Formality and integrate it directly into the language by publishing to Moonad. Or
+  deploy a cool app that uses Moonad's IO infrastructure. Soon we'll have toolchain in
+  place for you to publish in an automated way, but for now, you can do so by making a
+  PR to the [Moonad lib](https://github.com/moonad/Moonad/tree/master/lib).
+- The documentation needs helps. One of the best ways you can help us improve it is just ask
+  questions and give feedback on [on Telegram](https://t.me/formality_lang)! Bonus points if
+  you mention @d4hines so we can make sure it gets compiled into the FAQ.
+- Finally, there are lots of fascinating problems to solve in the language itself. We need 
+  all the help we can get for the items in the roadmap - or, if we've missed the thing you
+  want most, send us a PR or let us know [on Telegram](https://t.me/formality_lang). Formality
+  is a vast and rich frontier: who knows what dependently-typed glories await the intrepid?
+
+[Insert one last quote here as an outro. We need some Terry Pratchet or sci-fi.]

--- a/README.md
+++ b/README.md
@@ -108,8 +108,7 @@ Installation
 
 5. Type `fm`.
 
-This will type-check every `.fm` file on the `moonad` directory For more
-information and commands, check the [documentation](DOCUMENTATION.md).
+This will type-check every `.fm` file on the `moonad` directory.
 
 Commands
 ========

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Installation
 
 3. Clone the Moonad libraries: `git clone http://github.com/moonad/moonad`.
 
-4. Enter the directory with `cd moonad`.
+4. Enter the directory with `cd moonad/lib`.
 
 5. Type `fm`.
 

--- a/README.md
+++ b/README.md
@@ -138,9 +138,10 @@ Hello.world: IO(Unit)
 The first expression `Hello.world` defines a function called `world` in
 the `Hello` namespace (all definitions must be namespaced with the same
 name as the file they're found in).
-The type of this expression is `IO(Unit)` (more about that later).
+The type of this expression is `IO(Unit)` (more about that later in the
+[tutorial](TUTORIAL.md)).
 
-Let's try running our little program. On a command line, run:
+Let's try running our little program. On a command line, enter:
 
 ```
 fmio Hello.world
@@ -152,16 +153,16 @@ console. Let's look at each of these steps in a little more detail:
 
 ### 📦 Dependencies
 Formality will discover it doesn't have definitions for `IO(Unit)`
-and `IO.print`, and wil download them from [moonad.org](moonad.org).
+and `IO.print`, and will download them from [moonad.org](moonad.org).
 Formality doesn't have a notion of packages or a central package
-repository. Instead, users can post definitions to Moonad, making
+repository; instead, users can post definitions to Moonad, making
 them globally available for all other users, essentially extending the 
 language itself. This is Formality's philosophy on pretty much everything:
 keep the language as small and diamond-perfect as possible, but make it 
 easy to extend and share.
 
 ### ✔️ Type Checking
-With all the definitions in place, Formality will sure
+With all the definitions in place, Formality will make sure
 every definition fulfills its type. This process is *much* more powerful
 in Formality than in traditional languages: as in proof assistants like
 Coq and Agda, types can express deep properties about your programs, and
@@ -178,7 +179,8 @@ quite clean too! Check it out yourself by running:
   ```
 Javascript is currently the default runtime for Formality, and the one we recommend
 for learning the language. But, as mentioned, Haskell and EVM runtimes exist. In
-fact, writing a new runtime in your favorite language is simple and a nice weekend project - check out our tutorial [TODO - tutorial is a work in progress; in the
+fact, writing a new runtime in your favorite language is simple and a nice weekend project - 
+check out our tutorial on the subject [TODO - this tutorial is a work in progress; in the
 meantime, everything you'd need to implement is in [this file](https://github.com/moonad/Formality/blob/master/javascript/FormalityCore.js)]!
 
 ### 🚀 Run
@@ -206,7 +208,8 @@ Reading and printing to the console raises an important issue: Formality is
 a language without side-effects - as in languages like Haskell and Elm, all
 functions are completely pure (i.e, cannot read or write mutable state). Rather
 than issuing side-effects directly, the standard library defines datatypes that
-_describe_ the effects, which are then interpreted by the runtime.
+_describe_ the effects, which are then interpreted by the runtime. This is described
+at length in [IO section of the tutorial][TODO write IO section].
 
 ### 💡 Datatypes, Functions, and Proofs
 
@@ -221,6 +224,11 @@ down to three parts:
 
 3. Propose and prove theorems about your datatypes and functions.
 
+While the first two are commonplace for programmers and the last is usually relegated to
+mathematicians, Formality enables all three in the same simple language, making it a
+powerful *lingua franca* for the exchange of ideas in math, computer science, and software
+engineering.
+
 Learning More
 =============
 
@@ -229,7 +237,7 @@ you'll be proving theorems to the moon and back in no time (throw a little of th
 our way, eh?).
 
 Do you dream in Pi types and eat monoids for breakfast? You'll probably want
-to see the [specification](FMC_SPECIFICATION.md) (it's incomplete, but still
+to see the [specification](FMC_SPECIFICATION.md) (it's incomplete and slightly dated, but still
 covers a lot of ground).
 
 Questions? Queries? Quagmires? Conundrums? Perhaps we've covered it in the [FAQ](./FAQ.md).

--- a/THEOREM_PROVING_TUTORIAL.md
+++ b/THEOREM_PROVING_TUTORIAL.md
@@ -79,7 +79,7 @@ function foo(a : Number, b : Number) : Number {
 };
 ```
 
-How can Formality know that `abs(b) + 1` isn't `0`? Intuitivelly, we know it is
+How can Formality know that `abs(b) + 1` isn't `0`? Intuitively, we know it is
 true: the absolute of a number plus one can't be `0`. But how is the compiler
 supposed to know? That's where theorem proving shines.
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -136,7 +136,7 @@ On line 24:
 
 Coming from a traditional statically typed language, all this might seem
 magical, but `Equal` isn't a primitive: it's just a normal datatype similar
-to our `Bool` type, except that that it accepts parameters, and the type of
+to our `Bool` type, except that it accepts parameters, and the type of
 `Equal` *depends on its arguments* (hence, Formality is called
 a dependently typed language).
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1,3 +1,4 @@
+# A First Look at Formality
 
 ### 🔟 The Bool Type
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -210,8 +210,8 @@ case analysis on a value, you can access that value's `self` field for its respe
 
 What can you do with the `self` field? If you permit some hand-waving, the `self` field
 lets you *specialize* a variable any time you do case analysis on it.
-So, in the example above, both values of `b.self` are specialized to `Bool.true`, and, as
-we noted proving `Bool.true == Bool.true` is easy.
+So, in the example above, both values of `b.self` are specialized to `Bool.true` in the
+first branch, and, as we noted, proving `Bool.true == Bool.true` is easy.
 
 To illustrate the importance of `b.self`, let's try omitting them and 
 just using `b`:

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -26,7 +26,7 @@ T Bool
 ```
 
 `T` is a keyword to define a new type. `Bool` is the name of the type, and
-`true` and `false` are its two values, or _constructors_.
+`Bool.true` and `false` are its two values, or _constructors_.
 
 Try type-checking our new definition:
 ```
@@ -175,8 +175,8 @@ On line 20:
 What Formality is astutely observing is that `Bool.not(Bool.not(b))` is not
 equal to b _in the sense of identical with_ `b`, just like "evening star" and
 "morning star" are two unequal phrases both referring to Venus. Formality will
-(this may seem
-pedantic, but it is called _Formality_ after all).
+only consider two things equal when they evaluate to exactly the same terms
+(this may seem pedantic, but it is called _Formality_ after all).
 
 Formality requires more evidence before admitting our assertion. As usual,
 this comes down to case analysis - we'll prove the statement holds for

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1,0 +1,289 @@
+
+### 🔟 The Bool Type
+
+Before we can solve the world's problems, we need some datatypes that describe them.
+The Booleans are a good starting place. Make a new file called `Bool.fm` and copy this
+into it:
+
+```c
+T Bool
+| Bool.true;
+| Bool.false;
+```
+
+`T` is a keyword to define a new type. `Bool` is the name of the type, and
+`true` and `false` are its two values, or _constructors_.
+
+Try type-checking our new definition:
+```
+fm Bool
+```
+You'll see the following output, indicating the type of each new term:
+```
+Type-checking:
+Bool: Type
+Bool.true: Bool
+Bool.false: Bool
+
+All terms check.
+
+Reducing 'Bool':
+self_Bool<P: (self: Bool) -> Type> -> (Bool.true: P((Bool.true) (Bool.false) Bool.true)) -> (Bool.false: P((Bool.true) (Bool.false) Bool.false)) -> P(self_Bool)
+```
+(You can ignore `self_Bool` for now - we'll cover it later.)
+
+### ➡️ A Bool function
+> Every interesting program involves some kind of case-analysis.
+>
+> Gerald Sussman
+
+Now that we have some data to work with, let's write a function that can 
+manipulate it. The simplest boolean function is negation, i.e., a function
+that converts `Bool.true` to
+`Bool.false` and `Bool.false` to `Bool.true`. Add the following to `Bool.fm`:
+
+```c
+Bool.not(b: Bool): Bool  // Bool.not receives "b of type Bool" and returns "Bool"
+  case b:                // Inspect the value of b...
+  | Bool.true => Bool.false; // If it is true, return false.
+  | Bool.false  => Bool.true;  // If it is false, return true.
+```
+
+A few things of note about case analysis:
+- Currently, unlike most functional languages, Formality doesn't support
+  full pattern matching and instead uses the orders of the constructors in
+  the declaration as the order of the cases (notice for example that `Bool.true`
+  is first in the case analysis, just as it is when we declared it). Full
+  support for pattern matching is on the roadmap.
+- As a consequence of the above, everything between the `|` and `=>` is a 
+  just a comment.
+
+As a matter of syntax-sugar, you can also use the `if` keyword:
+```c
+Bool.not(b: Bool): Bool
+  if b then
+    Bool.false
+  else
+    Bool.true
+```
+The `if` keyword works on any two-valued type, using the first constructor
+as the "true" case and the second as the "false" case.
+
+### A Bool theorem
+
+> Who has despised the day of small beginnings?
+>
+> Zechariah 4:10
+
+Let's write our first proof in Formality! We'll start small: a proof that
+`Bool.true` is equal to `Bool.true`. To do this, we need to invoke a deep
+magic that lies at the heart of Formality: types are logical propositions,
+and programs are their proofs. If that doesn't make sense yet, don't worry -
+for now, the important bit is that we prove things in Formality by writing
+normal datatypes and functions (just like everything else!).
+
+Here's the code:
+```
+Bool.true_is_true: Equal(Bool, Bool.true, Bool.true)
+  Equal.to<Bool, Bool.true>
+```
+
+Here, `Equal.to` is a constructor for the `Equal` datatype that accepts
+a type and a value of that type and returns a proof that the value is equal
+to itself. Try type checking the term:
+
+```
+fm Bool.true_is_true
+```
+
+For comparison, try passing `Bool.false` to `Equal.to` instead:
+
+```
+Bool.true_is_true: Equal(Bool, Bool.true, Bool.true)
+  Equal.to<Bool, Bool.false>
+```
+You'll get the following error:
+
+```
+Found 1 type error(s):
+
+Inside Bool.true_is_true:
+Found type... Equal(Bool,Bool.false,Bool.false)
+Instead of... Equal(Bool,Bool.true,Bool.true)
+On line 24:
+    20| Bool.not_false_is_true : The(Bool, Bool.true)
+    21|   The.value<Bool>(Bool.not(Bool.false))
+    22|
+    23| Bool.true_is_true: Equal(Bool, Bool.true, Bool.true)
+    24|   Equal.to<Bool, Bool.false>
+```
+
+Notice that we've encoded facts about _data values_ into the _types_
+of functions. This is power of dependent types, and we'll be taking that
+power to its limit. Go ahead and change it back so things type check correctly.
+
+### ✨ A Slightly More Interesting Bool Theorem
+> The reference of 'evening star' would be the same as that of 'morning star',
+> but not the sense.
+> 
+> Gottlob Frege, On Sense and Reference
+
+Let's try proving a more interesting fact about Booleans, namely, that negation
+is it's own inverse: for any boolean `b`, `not(not(b)) == b`. 
+
+Copy the definition below and try type checking it with the `fm` command:
+```c
+Bool.not_not_is_b(b: Bool): Equal(Bool, Bool.not(Bool.not(b)), b)
+  Equal.to<Bool, b>
+```
+
+Hmm. Obviously, something didn't quite work:
+```c
+Found type... Equal(Bool)(b)(b)
+Instead of... Equal(Bool)(Bool.not(Bool.not(b)))(b)
+With context:
+- b : Bool
+On line 20:
+    ...
+    19| Bool.not_not_is_b(b: Bool): Equal(Bool, Bool.not(Bool.not(b)), b)
+    20|   Equal.to<Bool, Bool.true>
+    ...
+```
+
+What Formality is astutely observing is that `Bool.not(Bool.not(b))` is not
+equal to b _in the sense of identical with_ `b`, just like "evening star" and
+"morning star" two unequal phrases both referring to Venus (this may seem
+pedantic, but it is called _Formality_ after all).
+
+Formality requires more evidence before admitting our assertion. As usual,
+this comes down to case analysis:
+```c
+Bool.not_not_is_b(b: Bool): Equal(Bool, Bool.not(Bool.not(b)), b)
+  case b:
+  | Bool.true => Equal.to<Bool, Bool.true>;
+  | Bool.false => Equal.to<Bool, Bool.false>;
+  : Equal(Bool, Bool.not(Bool.not(b.self)), b.self);
+```
+.....................TODO fix al this...............
+
+Case analysis "breaks apart" a generic `Bool` type into a more specific
+`Bool.true` type (in the first branch) or `Bool.false` type (in second).
+With the type specialized on each branch, 
+
+The last line tells Formality the type returned by the case expression, with one
+quirk: we use `b.self` to tell Formality to **specialize** that type using the
+concrete value of `b` inside each branch. On the first branch, `b = Bool.true`,
+so `Equal(Bool, Bool.not(Bool.not(b.self)), b.self)` is specialized to
+`Equal(Bool, Bool.not(Bool.not(Bool.true)), Bool.true)`, which reduces to
+`Equal(Bool, Bool.true, Bool.true)`. This allow us to write
+`Equal.to<Bool, Bool.true>` identical, we can use `Equal.to`. The same
+reasoning goes for the last branch. Once all branches are correctly filled,
+Formality **generalizes** `b.self` to the matched value `b`, causing the whole
+`case` expression to have type `Equal(Bool, Bool.not(Bool.not(b)), b)`. This
+completes our first proof!
+.......
+
+The Nat Type
+------------
+
+The second type we're going to write is that of natural numbers, i.e.,
+non-negative integers. It can be written like this:
+
+```c
+T Nat
+| zero;
+| succ(pred: Nat);
+```
+
+In other words, a `Nat` is either `zero`, or the successor of another `Nat`. For
+example, `2` is the successor of the successor of `zero`, and can be written as
+`Nat.succ(Nat.succ(Nat.zero))`. With the `Nat` type, we're able to uniquely
+represent any non-negative integer.
+
+A Nat function
+--------------
+
+Let's write the addition on `Nat`:
+
+```c
+Nat.add(n: Nat, m: Nat): Nat
+  case n:
+  | m;
+  | Nat.succ(Nat.add(n.pred, m));
+```
+
+Notice that Formality's `case` expression allows us to access the fields
+contained inside the matched values inside their respective cases, with a
+`value.field` name. That is why we can write `n.pred` inside the second case. It
+is not a field accessor: `n.pred` is the actual name of the variable.
+
+The way `add` works is by recursing on the first argument, adding 1 to the result
+on each recursive call. It can be better explained by an example:
+
+```
+add(succ(succ(succ(zero))), succ(succ(zero)))   // add(3, 2)
+= succ(add(succ(succ(zero)), succ(succ(zero)))) // 1 + add(2, 2)
+= succ(succ(add(succ(zero), succ(succ(zero))))) // 1 + 1 + add(1, 2)
+= succ(succ(succ(add(zero, succ(succ(zero)))))) // 1 + 1 + 1 + add(0, 2)
+= succ(succ(succ(succ(succ(zero)))))            // 1 + 1 + 1 + 2
+```
+
+Since `Nat` is a common type, we can write it with numeric literals, which are
+desugared to `Nat.succ(Nat.succ(...Nat.zero))`. Let's test it by adding
+`123456789 + 987654321`:
+
+```c
+Docs.nat_test: Nat
+  Nat.add(123456789, 987654321)
+```
+
+Running `fmcio Docs.nat_test` outputs `1111111110n`. That's because Formality
+compiles `Nat` to JavaScript `BigInt`, which is a very fast implementation of
+integers.
+
+A Nat theorem
+-------------
+
+Let's now prove two theorems: `add(0, a) == a` and `add(a, 0) == a`. The first
+one is easy:
+
+```c
+Docs.0_plus_a_is_a(a: Nat): Equal(Nat, Nat.add(0, a), a)
+  Equal.to<Nat, a>
+```
+
+That's because, due to the way `Nat.add` was written, `Nat.add(0, a)` reduces to
+`a`. This allow us to use `Equal.to` directly. The second theorem is harder,
+though. If we try to prove it like the first, we get the following error:
+
+```c
+Found type... Equal(Nat)(a)(a)
+Instead of... Equal(Nat)(Nat.add(a)(Nat.zero))(a)
+With context:
+- a : Nat
+On line 32:
+    28| Docs.0_plus_a_is_a(a: Nat): Equal(Nat, Nat.add(0, a), a)
+    29|   Equal.to<Nat, a>
+    30|
+    31| Docs.a_plus_0_is_a(a: Nat): Equal(Nat, Nat.add(a, 0), a)
+    32|   Equal.to<Nat, a>
+    33|
+    34| //Docs.bool_show: IO(Unit)
+    35|   //IO.print(Bool.show(Bool.true))
+```
+
+That's because `Nat.add` matches on the first argument, which, here, is a
+variable, so it gets stuck, not unlike `not(not(b)) == b`. For that reason, we
+must proceed by case analysis:
+
+```c
+Docs.a_plus_0_is_a(a: Nat): Equal(Nat, Nat.add(a, 0), a)
+  case a:
+  | Equal.to<Nat, Nat.zero>;
+  | let ind = Docs.a_plus_0_is_a(a.pred)
+    let app = Equal.apply<Nat, Nat, Nat.add(a.pred, Nat.zero), a.pred, Nat.succ, ind>
+    app;
+  : Equal(Nat, Nat.add(a.self, 0), a.self);
+```
+
+... to be continued ...


### PR DESCRIPTION
Hi all,

I'm trying to clean up the documentation (prompted in part by #93). 

Here are my guiding principles:

1. The documentation should be attractive, well formatted, and fun to read, since new users are going to have spend
a lot of time with it. I love literature references, and have sprinkled more throughout. It only takes a few lines of Terry Pratchet
to burn a README into someone's memory (I didn't manage to work any Terry Pratchet in specifically - if you think of any, please suggest!)
2. The documentation should cater more to FP newbies than Haskell wizards, since there are many more of the former than the latter, and the latter have always been able to fend for themselves.
3. In line with the last point, we should write the docs to build up both FP and theorem proving from the ground up. Everything should be simple and thorough, leaving the reader wondering "Why am I not using this at work?". Elm and Rrst both do this well, I think.

I've utterly fallen short of these goals - for one, this is all still a work in progress (except perhaps the README), but I figured
it would be good to get your feedback early in case anything needed course correction.

Here's what I've done:
- Refactored the vast majority of the tutorial out of the README and into a file called TUTORIAL.md.
- Fleshed out the tutorial more. It was fairly spartan. Note, I've only gotten through the sections dealing with bools - I haven't gotten to Nat's yet.
- Added an FAQ created from the Roam database. It's super rough - some questions are unanswered and some just have copy-pasta from the chat. 
- Spell checking and updating the table of contents in various places.

As to achieving goal 3, we might need to port over a book like _Programming Language Foundations in Agda_ to Formality. I'm really not sure of the best approach here.

Let me know what you think.

DH