### PR TITLE
throw on unhandled terms

### DIFF
--- a/javascript/FormalityComp.js
+++ b/javascript/FormalityComp.js
@@ -220,6 +220,8 @@ function infer(term, defs, ctx = fmc.Nil()) {
         comp: Str(term.strx),
         type: fmc.Ref("String"),
       };
+    default:
+      throw "Unhandled term: " + JSON.stringify(term);
   }
 };
 

--- a/javascript/FormalityToJS.js
+++ b/javascript/FormalityToJS.js
@@ -849,7 +849,7 @@ function compile(main, defs, only_expression = false) {
   };
 
   if (isio) {
-    code += "  var rdl = require('readline').createInterface({input:process.stdin,output:process.stdout});\n";
+    code += "  var rdl = require('readline').createInterface({input:process.stdin,output:process.stdout,terminal:false});\n";
     code += "  var run = (p) => {\n";
     code += "    switch (p._) {\n";
     code += "      case 'IO.end': return Promise.resolve(p.value);\n";


### PR DESCRIPTION
This results in a better error message for issue #100 :

```
Unhandled term: {"ctor":"Cse","name":"xs#J","func":{"ctor":"Loc","from":60,"upto":68,"expr":{"ctor":"Ann","done":true,"expr":{"ctor":"Var","indx":"xs#2"},"type":{"ctor":"Ref","name":"String"}}},"info":[{"ctor":"Ext","head":["xs",{"ctor":"Ann","done":true,"expr":{"ctor":"Var","indx":"xs#2"},"type":{"ctor":"Ref","name":"String"}}],"tail":{"ctor":"Ext","head":["sep",{"ctor":"Ann","done":true,"expr":{"ctor":"Var","indx":"sep#1"},"type":{"ctor":"Ref","name":"String"}}],"tail":{"ctor":"Nil","size":0},"size":1},"size":2},[null,null,null]]}
```