### PR TITLE
README: Use singular 'they' as a gender-neutral pronoun

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Quick Introduction
 
 Why make it hard? Formality aims to frame advanced concepts in ways that
 everyone can understand. For example, if you ask a Haskeller to sum a list of
-positive ints (Nats), he might write:
+positive ints (Nats), they might write:
 
 ```c
 sum(list: List(Nat)): Nat
@@ -159,7 +159,7 @@ Main: IO(Unit)
   }
 ```
 
-Or, if he is enlightened enough:
+Or, if they are enlightened enough:
 
 ```c
 sum(list: List(Nat)): Nat


### PR DESCRIPTION
Hi :) 

I thought changing a couple of words in the README would help to make this (awesome, by the way) project feel a little more welcoming. 

In some languages (French is one of them), one can use a *generic he* to address an interlocutor whose gender is not known. However, in contemporary English, the pronoun 'they' is widely preferred as a gender-neutral pronoun.