### PR TITLE
Change Nat.to_bits behavior and add more Word primitives

### DIFF
--- a/base/Nat/to_bits.kind
+++ b/base/Nat/to_bits.kind
@@ -1,5 +1,5 @@
 Nat.to_bits(n: Nat): Bits
   case n {
-    zero: Bits.e,
+    zero: Bits.o(Bits.e),
     succ: Bits.inc(Nat.to_bits(n.pred))
   }

--- a/base/Word/and.kind
+++ b/base/Word/and.kind
@@ -1,2 +1,14 @@
 Word.and<size: Nat>(a: Word(size), b: Word(size)): Word(size)
-  Word.and<size>(a,b)
+  case a with b: Word(a.size) = b {
+    e: Word.e,
+    o: case b with a.pred: Word(Nat.pred(b.size)) = a.pred {
+      e: Word.e,
+      o: Word.o<b.size>(Word.and<b.size>(a.pred, b.pred)),
+      i: Word.o<b.size>(Word.and<b.size>(a.pred, b.pred))
+    } : Word(b.size),
+    i: case b with a.pred: Word(Nat.pred(b.size)) = a.pred {
+      e: Word.e,
+      o: Word.o<b.size>(Word.and<b.size>(a.pred, b.pred)),
+      i: Word.i<b.size>(Word.and<b.size>(a.pred, b.pred))
+    } : Word(b.size)
+  } : Word(a.size)

--- a/base/Word/full_mul.kind
+++ b/base/Word/full_mul.kind
@@ -1,0 +1,4 @@
+Word.full_mul(size: Nat)(a: Word(size), b: Word(size)): Word(Nat.add(size, size))
+  let new_a = Word.trim<size>(Nat.add(size, size), a)
+  let new_b = Word.trim<size>(Nat.add(size, size), b)
+  Word.mul<Nat.add(size, size)>(new_a, new_b)

--- a/base/Word/mul.kind
+++ b/base/Word/mul.kind
@@ -1,2 +1,2 @@
-Word.mul<size: Nat>(a: Word(size), b: Word(size)): Word(size)
-  Word.mul<size>(a,b)
+Word.mul(size: Nat)(a: Word(size), b: Word(size)): Word(size)
+  Word.mul.go<size, size>(a, b, Word.zero(size))

--- a/base/Word/mul/go.kind
+++ b/base/Word/mul/go.kind
@@ -1,0 +1,6 @@
+Word.mul.go<size: Nat, b_size: Nat>(a: Word(size), b: Word(b_size), acc: Word(b_size)): Word(b_size)
+  case a {
+    e: acc,
+    o: Word.mul.go<a.size, b_size>(a.pred, Word.shift_left1<b_size>(b), acc),
+    i: Word.mul.go<a.size, b_size>(a.pred, Word.shift_left1<b_size>(b), Word.add<b_size>(b, acc))
+  } : Word(b_size)

--- a/base/Word/not.kind
+++ b/base/Word/not.kind
@@ -1,0 +1,6 @@
+Word.not<size: Nat>(word: Word(size)): Word(size)
+  case word {
+    e: Word.e,
+    o: Word.i<word.size>(Word.not<word.size>(word.pred)),
+    i: Word.o<word.size>(Word.not<word.size>(word.pred))
+  } : Word(word.size)

--- a/base/Word/or.kind
+++ b/base/Word/or.kind
@@ -1,2 +1,14 @@
 Word.or<size: Nat>(a: Word(size), b: Word(size)): Word(size)
-  Word.or<size>(a,b)
+  case a with b: Word(a.size) = b {
+    e: Word.e,
+    o: case b with a.pred: Word(Nat.pred(b.size)) = a.pred {
+      e: Word.e,
+      o: Word.o<b.size>(Word.or<b.size>(a.pred, b.pred)),
+      i: Word.i<b.size>(Word.or<b.size>(a.pred, b.pred))
+    } : Word(b.size),
+    i: case b with a.pred: Word(Nat.pred(b.size)) = a.pred {
+      e: Word.e,
+      o: Word.i<b.size>(Word.or<b.size>(a.pred, b.pred)),
+      i: Word.i<b.size>(Word.or<b.size>(a.pred, b.pred))
+    } : Word(b.size)
+  } : Word(a.size)

--- a/base/Word/shift_left.kind
+++ b/base/Word/shift_left.kind
@@ -1,2 +1,5 @@
-Word.shift_left: <size: Nat> -> Nat -> Word(size) -> Word(size)
-  Word.shift_left
+Word.shift_left<size: Nat>(n: Nat, value: Word(size)): Word(size)
+  case n {
+    zero: value,
+    succ: Word.shift_left<size>(n.pred, Word.shift_left1<size>(value))
+  } : Word(size)

--- a/base/Word/shift_left1.kind
+++ b/base/Word/shift_left1.kind
@@ -1,0 +1,6 @@
+Word.shift_left1<size: Nat>(word: Word(size)): Word(size)
+  case word {
+    e: Word.e,
+    o: Word.o<word.size>(Word.shift_left1.aux<word.size>(word.pred, Bool.false)),
+    i: Word.o<word.size>(Word.shift_left1.aux<word.size>(word.pred, Bool.true))
+  } : Word(word.size)

--- a/base/Word/shift_left1/aux.kind
+++ b/base/Word/shift_left1/aux.kind
@@ -1,0 +1,12 @@
+Word.shift_left1.aux<size: Nat>(word: Word(size), prev: Bool): Word(size)
+  case word {
+    e: Word.e,
+    o: case prev {
+      true : Word.i<word.size>(Word.shift_left1.aux<word.size>(word.pred, Bool.false)),
+      false: Word.o<word.size>(Word.shift_left1.aux<word.size>(word.pred, Bool.false))
+    }
+    i: case prev {
+      true : Word.i<word.size>(Word.shift_left1.aux<word.size>(word.pred, Bool.true)),
+      false: Word.o<word.size>(Word.shift_left1.aux<word.size>(word.pred, Bool.true))
+    }
+  } : Word(word.size)

--- a/base/Word/shift_right.kind
+++ b/base/Word/shift_right.kind
@@ -1,2 +1,5 @@
-Word.shift_right: <size: Nat> -> Nat -> Word(size) -> Word(size)
-  Word.shift_right
+Word.shift_right<size: Nat>(n: Nat, value: Word(size)): Word(size)
+  case n {
+    zero: value,
+    succ: Word.shift_right<size>(n.pred, Word.shift_right1<size>(value))
+  } : Word(size)

--- a/base/Word/shift_right1.kind
+++ b/base/Word/shift_right1.kind
@@ -1,0 +1,6 @@
+Word.shift_right1<size: Nat>(word: Word(size)): Word(size)
+  case word {
+    e: Word.e,
+    o: Word.shift_right1.aux<word.size>(word.pred),
+    i: Word.shift_right1.aux<word.size>(word.pred)
+  } : Word(word.size)

--- a/base/Word/shift_right1/aux.kind
+++ b/base/Word/shift_right1/aux.kind
@@ -1,0 +1,6 @@
+Word.shift_right1.aux<size: Nat>(word: Word(size)): Word(Nat.succ(size))
+  case word {
+    e: Word.o!(Word.e),
+    o: Word.o<Nat.succ(word.size)>(Word.shift_right1.aux<word.size>(word.pred)),
+    i: Word.i<Nat.succ(word.size)>(Word.shift_right1.aux<word.size>(word.pred))
+  } : Word(Nat.succ(word.size))

--- a/base/Word/take.kind
+++ b/base/Word/take.kind
@@ -1,0 +1,9 @@
+Word.take<size: Nat>(len: Nat, word: Word(size)): Word(Nat.min(len, size))
+  case len {
+    zero: Word.e
+    succ: case word {
+      e: Word.e,
+      o: Word.o!(Word.take!(len.pred, word.pred)),
+      i: Word.i!(Word.take!(len.pred, word.pred))
+    }!
+  }!


### PR DESCRIPTION
This allows for example to show `"0"` when using `Bits.show(Nat.to_bits(0))` instead of the empty string.