### PR TITLE
Add Bits.div, Bits.mod and related primitives

### DIFF
--- a/base/Bits/and.kind
+++ b/base/Bits/and.kind
@@ -1,0 +1,14 @@
+Bits.and(a: Bits, b: Bits): Bits
+  case a {
+    e: b,
+    o: case b {
+      e: a,
+      o: Bits.o(Bits.and(a.pred, b.pred)),
+      i: Bits.o(Bits.and(a.pred, b.pred))
+    }
+    i: case b {
+      e: a,
+      o: Bits.o(Bits.and(a.pred, b.pred)),
+      i: Bits.i(Bits.and(a.pred, b.pred))
+    }
+  }

--- a/base/Bits/cmp.kind
+++ b/base/Bits/cmp.kind
@@ -1,0 +1,2 @@
+Bits.cmp(a: Bits, b: Bits): Cmp
+  Bits.cmp.go(a, b, Cmp.eql)

--- a/base/Bits/cmp/go.kind
+++ b/base/Bits/cmp/go.kind
@@ -1,0 +1,18 @@
+Bits.cmp.go(a: Bits, b: Bits, c: Cmp): Cmp
+  case a {
+    e: case b {
+      e: c,
+      o: Bits.cmp.go(Bits.e, b.pred, c),
+      i: Cmp.ltn
+    },
+    o: case b {
+      e: Bits.cmp.go(a.pred, Bits.e, c),
+      o: Bits.cmp.go(a.pred, b.pred, c),
+      i: Bits.cmp.go(a.pred, b.pred, Cmp.ltn)
+    },
+    i: case b {
+      e: Cmp.gtn,
+      o: Bits.cmp.go(a.pred, b.pred, Cmp.gtn),
+      i: Bits.cmp.go(a.pred, b.pred, c)
+    }
+  }

--- a/base/Bits/div.kind
+++ b/base/Bits/div.kind
@@ -1,2 +1,9 @@
 Bits.div(a: Bits, b: Bits): Bits
-  Bits.div(a, b)
+  let a_size = Bits.size(a)
+  let b_size = Bits.size(b)
+  if Nat.ltn(a_size, b_size) then
+    Bits.o(Bits.e)
+  else
+    let shift = Nat.sub(a_size, b_size)
+    let shift_copy = Bits.shift_left(shift, b)
+    Bits.div.go(shift, a, shift_copy, Bits.e)

--- a/base/Bits/div/go.kind
+++ b/base/Bits/div/go.kind
@@ -1,0 +1,17 @@
+Bits.div.go(shift: Nat, sub_copy: Bits, shift_copy: Bits, value: Bits): Bits
+  let {bit_on, new_value} = if Bits.gte(sub_copy, shift_copy) then
+    {true,  Bits.i(value)}
+  else
+    {false, Bits.o(value)}
+
+  case shift {
+    zero:
+      new_value,
+    succ:
+      let new_shift_copy = Bits.shift_right(1, shift_copy)
+      let new_sub_copy = if bit_on then
+        Bits.sub(sub_copy, shift_copy)
+      else
+        sub_copy
+      Bits.div.go(shift.pred, new_sub_copy, new_shift_copy, new_value)
+  }

--- a/base/Bits/eql.kind
+++ b/base/Bits/eql.kind
@@ -1,18 +1,2 @@
 Bits.eql(a: Bits, b: Bits): Bool
-  case a {
-    e: case b {
-      e: Bool.true,
-      o: Bool.false,
-      i: Bool.false,
-    },
-    o: case b {
-      e: Bool.false,
-      o: Bits.eql(a.pred, b.pred),
-      i: Bool.false,
-    },
-    i: case b {
-      e: Bool.false,
-      o: Bool.false,
-      i: Bits.eql(a.pred, b.pred),
-    }
-  }
+  Cmp.as_eql(Bits.cmp(a, b))

--- a/base/Bits/gte.kind
+++ b/base/Bits/gte.kind
@@ -1,0 +1,2 @@
+Bits.gte(a: Bits, b: Bits): Bool
+  Cmp.as_gte(Bits.cmp(a, b))

--- a/base/Bits/gtn.kind
+++ b/base/Bits/gtn.kind
@@ -1,0 +1,2 @@
+Bits.gtn(a: Bits, b: Bits): Bool
+  Cmp.as_gtn(Bits.cmp(a, b))

--- a/base/Bits/lte.kind
+++ b/base/Bits/lte.kind
@@ -1,0 +1,2 @@
+Bits.lte(a: Bits, b: Bits): Bool
+  Cmp.as_lte(Bits.cmp(a, b))

--- a/base/Bits/ltn.kind
+++ b/base/Bits/ltn.kind
@@ -1,0 +1,2 @@
+Bits.ltn(a: Bits, b: Bits): Bool
+  Cmp.as_ltn(Bits.cmp(a, b))

--- a/base/Bits/mod.kind
+++ b/base/Bits/mod.kind
@@ -1,2 +1,3 @@
 Bits.mod(a: Bits, b: Bits): Bits
-  Bits.mod(a, b)
+  let q = Bits.div(a, b)
+  Bits.sub(a, Bits.mul(b, q))

--- a/base/Bits/not.kind
+++ b/base/Bits/not.kind
@@ -1,0 +1,6 @@
+Bits.not(bits: Bits): Bits
+  case bits {
+    e: Bits.e,
+    o: Bits.i(Bits.not(bits.pred)),
+    i: Bits.o(Bits.not(bits.pred)),
+  }

--- a/base/Bits/or.kind
+++ b/base/Bits/or.kind
@@ -1,0 +1,14 @@
+Bits.or(a: Bits, b: Bits): Bits
+  case a {
+    e: b,
+    o: case b {
+      e: a,
+      o: Bits.o(Bits.or(a.pred, b.pred)),
+      i: Bits.i(Bits.or(a.pred, b.pred))
+    }
+    i: case b {
+      e: a,
+      o: Bits.i(Bits.or(a.pred, b.pred)),
+      i: Bits.i(Bits.or(a.pred, b.pred))
+    }
+  }

--- a/base/Bits/shift_left.kind
+++ b/base/Bits/shift_left.kind
@@ -1,0 +1,5 @@
+Bits.shift_left(n: Nat, value: Bits): Bits
+  case n {
+    zero: value,
+    succ: Bits.o(Bits.shift_left(n.pred, value))
+  }

--- a/base/Bits/shift_right.kind
+++ b/base/Bits/shift_right.kind
@@ -1,0 +1,5 @@
+Bits.shift_right(n: Nat, value: Bits): Bits
+  case n {
+    zero: value,
+    succ: Bits.shift_right(n.pred, Bits.tail(value))
+  }

--- a/base/Bits/size.kind
+++ b/base/Bits/size.kind
@@ -1,0 +1,2 @@
+Bits.size(bits: Bits): Nat
+  Bits.size.go(bits, 0, 0)

--- a/base/Bits/size/go.kind
+++ b/base/Bits/size/go.kind
@@ -1,0 +1,6 @@
+Bits.size.go(bits: Bits, n: Nat, s: Nat): Nat
+  case bits {
+    e: s,
+    o: Bits.size.go(bits.pred, Nat.succ(n), s),
+    i: Bits.size.go(bits.pred, Nat.succ(n), Nat.succ(n))
+  }

--- a/base/Bits/trim.kind
+++ b/base/Bits/trim.kind
@@ -1,0 +1,9 @@
+Bits.trim(new_len: Nat, bits: Bits): Bits
+  case new_len {
+    zero: Bits.e,
+    succ: case bits {
+      e: Bits.o(Bits.trim(new_len.pred, Bits.e)),
+      o: Bits.o(Bits.trim(new_len.pred, bits.pred)),
+      i: Bits.i(Bits.trim(new_len.pred, bits.pred)),
+    }
+  }


### PR DESCRIPTION
This PR introduces mainly `Bits.div` and `Bits.rem` primitives and some related ones like `Bits.cmp`, `Bits.shift_left`, `Bits.shift_right` and `Bits.size`.

Note also that this PR significantly changes the way equality is handled for `Bits`.

Likewise for `Word`, `Bits` now uses internal `Cmp` type for equality and comparisons.
Equality is based on actual math, not structure anymore, in other words: `1001` equals `10010` (so ignoring leading zeros).

Today this is not the case and could have an impact in the codebase (`Bits.eql` is used at some places, e.g. in `Kind.Term.equal`).

This PR also brings bitwise binops and `Bits.trim` that are also present in `Word`.

Note I didn't do anything special regarding division by zero. Probably we would like a trap behavior (like it is today with `Nat.div` and in future with `Word.div`).