### PR TITLE
Fix BitsMap.delete

### DIFF
--- a/base/BitsMap/delete.kind
+++ b/base/BitsMap/delete.kind
@@ -3,7 +3,7 @@ BitsMap.delete<A: Type>(key: Bits, map: BitsMap(A)): BitsMap(A)
     new: BitsMap.new!,
     tie: case key {
       e: BitsMap.tie!(Maybe.none!, map.lft, map.rgt),
-      o: BitsMap.delete!(key.pred, map.lft),
-      i: BitsMap.delete!(key.pred, map.rgt)
+      o: BitsMap.tie!(map.val, BitsMap.delete!(key.pred, map.lft), map.rgt),
+      i: BitsMap.tie!(map.val, map.lft, BitsMap.delete!(key.pred, map.rgt))
     }
   }

--- a/base/String/cmp.kind
+++ b/base/String/cmp.kind
@@ -1,0 +1,15 @@
+String.cmp(a: String, b: String): Cmp
+  case a {
+    nil: case b {
+      nil: Cmp.eql,
+      cons: Cmp.ltn,
+    },
+    cons: case b {
+      nil: Cmp.gtn,
+      cons: case U16.cmp(a.head, b.head) {
+        ltn: Cmp.ltn,
+        eql: String.cmp(a.tail, b.tail),
+        gtn: Cmp.gtn,
+      }
+    },
+  }

--- a/base/U16/cmp.kind
+++ b/base/U16/cmp.kind
@@ -1,0 +1,4 @@
+U16.cmp(a: U16, b: U16): Cmp
+  open a
+  open b
+  Word.cmp!(a.value, b.value)


### PR DESCRIPTION
This PR ensures that `BitsMap.delete` will only delete the supplied key. It also adds the convenience functions `String.cmp` and `U16.cmp`.