### PR TITLE
Remove test defs that cause a stack overflow in the type checker

### DIFF
--- a/base/Fmt/sprintf.kind
+++ b/base/Fmt/sprintf.kind
@@ -114,39 +114,3 @@ Fmt.sprintf.example.empty: String
 
 Fmt.sprintf.example.percent: String
   Fmt.sprintf("%%")
-
-Fmt.sprintf.test.string1a: Fmt.arguments(List.nil!) == String
-  refl
-
-Fmt.sprintf.test.string1b: Fmt.arguments([Fmt.Specifier.char('a')]) == String
-  refl
-
-Fmt.sprintf.test.string1c: Fmt.arguments([Fmt.Specifier.char('a'), Fmt.Specifier.integer]) == Nat -> String
-  refl
-
-Fmt.sprintf.test.string2a: Fmt.arguments(Fmt.Parser.parse("a")) == String
-  refl
-
-Fmt.sprintf.test.string2: Fmt.sprintf("a") == "a"
-  refl
-
-Fmt.sprintf.test.string3a: Fmt.arguments(Fmt.Parser.parse("%d")) == Nat -> String
-  refl
-
-Fmt.sprintf.test.string3: Fmt.sprintf("%d")(1) == "1"
-  refl
-
-Fmt.sprintf.test.string4a: Fmt.arguments(Fmt.Parser.parse("%s world")) == String -> String
-  refl
-
-Fmt.sprintf.test.string4: Fmt.sprintf("%s world", "hello") == "hello world"
-  refl
-
-Fmt.sprintf.test.string5a: Fmt.arguments(Fmt.Parser.parse("%%")) == String
-  refl
-
-Fmt.sprintf.test.string5: Fmt.sprintf("%%") == "%"
-  refl
-
-Fmt.sprintf.test.string_and_number: Fmt.sprintf("%s %d!", "hello", 5) == "hello 5!"
-  refl


### PR DESCRIPTION
This doesn't fix the underlying issue, but does remove the stack overflow for now.

```
kind Fmt/sprintf.kind
/opt/homebrew/lib/node_modules/kind-lang/src/kind.js:6227
    function BitsMap$set$(_bits$2, _val$3, _map$4) {
                         ^

RangeError: Maximum call stack size exceeded
    at BitsMap$set$ (/opt/homebrew/lib/node_modules/kind-lang/src/kind.js:6227:26)
```