### PR TITLE
Refactor polymorphic types to use angle brackets

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -113,7 +113,7 @@ Mons.global_scr_mid: Pos32
 ```
 // A 2D map of game tiles
 Mons.Map: Type
-  Map(List(Mons.Object))
+  Map(List<Mons.Object>)
 
 create_new_map(...): Mons.Map
 ```
@@ -146,7 +146,7 @@ type Film {
   new(title: String, year: Nat)
 }
 
-main: List(Film)
+main: List<Film>
   let films = [
     Film.new("Fight Club ", 1999), 
     Film.new("Avatar", 2009),
@@ -169,19 +169,19 @@ type Film {
   new(title: String, year: Nat)
 }
 
-catalog: List(Film)
+catalog: List<Film>
   [ Film.new("Fight Club ", 1999), 
     Film.new("Avatar", 2009),
     Film.new("Passengers", 2016),
     Film.new("My Neighbor Totoro", 1988)
     Film.new("The Silence of the Lambs", 1991)]
 
-films_newer_than(year: Nat, films: List(Film)): List(Film)
+films_newer_than(year: Nat, films: List<Film>): List<Film>
   List.filter<_>( 
     (f) open f Nat.gtn(f.year, year), // anonymous function, that is, a function without a name
     films)
 
-main: List(Film)
+main: List<Film>
   let wishlist = films_newer_than(2008, catalog)
   wishlist
 ```

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -188,7 +188,7 @@ Nat.add(n: Nat, m: Nat): Nat
 `Nat.add` is a function which takes two `Nat`s and returns its sum.
 
 ```
-Bool.double_negation(b: Bool): Equal(Bool, Bool.not(Bool.not(b)), b)
+Bool.double_negation(b: Bool): Equal<Bool, Bool.not(Bool.not(b)), b>
 ```
 `Bool.double_negation` is a proof that for all `Bool`, its double negation is equal to itself.
 
@@ -197,7 +197,7 @@ Kind functions are self-dependently typed, you can optionally give a name
 to the input variable, and to the value of the function itself. For example,
 
 ```
-(n: Nat) Vector(Bool, n)
+(n: Nat) Vector<Bool, n>
 ```
 
 Is the type of a function that receives a `n: Nat` and returns a `Vector` of `n`
@@ -238,7 +238,7 @@ Can be written in Kind as:
 ```
 type List (A: Type) {
   nil
-  cons(head: A, tail: List(A))
+  cons(head: A, tail: List<A>)
 }
 ```
 
@@ -255,7 +255,7 @@ That can be written in Kind as:
 ```
 type Vector <A: Type> ~ (size: Nat) {
   nil                                      ~ (size = zero)
-  cons(n: Nat, head: A, tail: Vector(A,n)) ~ (size = succ(n))
+  cons(n: Nat, head: A, tail: Vector<A,n>) ~ (size = succ(n))
 }
 ```
 
@@ -305,7 +305,7 @@ The motive is optional: if it isn't provided, it will be replaced by a `hole`.
 For example, to sum a list, we write:
 
 ```
-sum(list: List(Nat)): Nat
+sum(list: List<Nat>): Nat
   case list {
     nil  : 0
     cons : list.head + sum(list.tail)
@@ -315,7 +315,7 @@ sum(list: List(Nat)): Nat
 This is the same as:
 
 ```
-sum(list: List(Nat)): Nat
+sum(list: List<Nat>): Nat
   case list {
     nil: 0
     cons: list.head + sum(list.tail)
@@ -325,7 +325,7 @@ sum(list: List(Nat)): Nat
 Which, for curiosity sake, is expanded to:
 
 ```
-sum(list: List(Nat)): Nat
+sum(list: List<Nat>): Nat
   def case_nil = 0
   def case_cons = (list.head, list.tail)
     Nat.add(list.head, sum(list.tail))
@@ -551,9 +551,9 @@ program for you. Without holes, Kind would be extremely more verbose. For
 example, the list of lists `[[1,2],[3,4]]`, in its full form, would be:
 
 ```
-List.cons<List(Nat)>(List.cons<Nat>(1, List.cons<Nat>(2, List.nil<Nat>)),
-List.cons<List(Nat)>(List.cons<Nat>(3, List.cons<Nat>(4, List.nil<Nat>)),
-List.nil<List(Nat)>))
+List.cons<List<Nat>>(List.cons<Nat>(1, List.cons<Nat>(2, List.nil<Nat>)),
+List.cons<List<Nat>>(List.cons<Nat>(3, List.cons<Nat>(4, List.nil<Nat>)),
+List.nil<List<Nat>>))
 ```
 
 With holes, you can write just:
@@ -669,7 +669,7 @@ execute a monadic computation and drop the result. You can also use local
 of `Monad.bind` and `Monad.pure`. For example,
 
 ```
-ask_user_age: IO(Nat)
+ask_user_age: IO<Nat>
   IO {
     var name = IO.get_line("What is your name?")
     IO.print("Welcome, " | name)
@@ -785,7 +785,7 @@ type String {
 }
 ```
 
-Note that Strings aren't the same as `List(Char)`. They're a new datatype in
+Note that Strings aren't the same as `List<Char>`. They're a new datatype in
 order to make efficient compilation simpler. Kind's type-checker expands
 string literals to strings when needed. For example, `"Hello"` is expanded to:
 
@@ -882,7 +882,7 @@ a == b
 The syntax above expands to:
 
 ```
-Equal(_, a, b)
+Equal<_, a, b>
 ```
 
 It is the type of propositional equality proofs. It is not a boolean equality
@@ -900,7 +900,7 @@ a != b
 The syntax above expands to:
 
 ```
-Not(Equal(_, a, b))
+Not(Equal<_, a, b>)
 ```
 
 It is the type of propositional inequality proofs. It is not a boolean
@@ -1146,21 +1146,21 @@ example, suppose you have the following values in your context:
 
 ```
 eq: 10 == 5 + 5
-xs: Vector(Nat, 10)
+xs: Vector<Nat, 10>
 ```
 
 Then you can use `rewrite` to "cast" the type of `xs`:
 
 ```
-let ys = xs :: rewrite x in Vector(Nat, x) with e
+let ys = xs :: rewrite x in Vector<Nat, x> with e
 ```
 
 And then you'll have:
 
 ```
 eq: 10 == 5 + 5
-xs: Vector(Nat, 10)
-ys: Vector(Nat, 5 + 5)
+xs: Vector<Nat, 10>
+ys: Vector<Nat, 5 + 5>
 ```
 
 In your context. Notice that `ys` is just `xs`, except with the type changed to

--- a/THEOREMS.md
+++ b/THEOREMS.md
@@ -29,14 +29,14 @@ If that looks alien to you, don't worry for now, it will become clear. The
 `Equal` type has only one constructor, `refl`, which has the following type:
 
 ```
-Equal.refl : (A: Type) -> (x: A) -> Equal(A,x,x)
+Equal.refl : (A: Type) -> (x: A) -> Equal<A,x,x>
 ````
 
 That means `refl` receives a type (`A`), and element `x` of type `A`, and
-returns `Equal(A,x,x)`. As an example, the program below:
+returns `Equal<A,x,x>`. As an example, the program below:
 
 ```
-two_is_two: Equal(Nat, 2, 2)
+two_is_two: Equal<Nat, 2, 2>
   Equal.refl(Nat, 2)
 ```
 
@@ -524,7 +524,7 @@ right_and_b_true(b: Bool): b == Bool.and(b, true)
   mirror(and_b_true(b))
 ```
 
-Here, `mirror : (A: Type) -> (a: A) -> (b: B) -> Equal(A,a,b) -> Equal(A,b,a)`
+Here, `mirror : (A: Type) -> (a: A) -> (b: B) -> Equal<A,a,b> -> Equal<A,b,a>`
 is a standard function that flips the two arguments of an equality. That is, it
 turns `a == b` into `b == a`. The lesson here is that not always we will prove
 equalities with `refl` directly. If we did that, every proof would be huge!
@@ -1358,22 +1358,22 @@ b`. For example, suppose we had the following context:
 
 ```
 eq: n == 2
-xs: Vector(Nat, n)
+xs: Vector<Nat, n>
 ```
 
 That is, we have a vector `xs` of `n` natural numbers, and a proof `eq` that `n
-== 2`. We can use `rewrite` and `eq` to cast `xs` to type `Vector(Nat, 2)`:
+== 2`. We can use `rewrite` and `eq` to cast `xs` to type `Vector<Nat, 2>`:
 
 ```
-let ys = xs :: rewrite x in Vector(Nat, x) with eq
+let ys = xs :: rewrite x in Vector<Nat, x> with eq
 ```
 
 This would give us the following context:
 
 ```
 eq: n == 2
-xs: Vector(Nat, n)
-ys: Vector(Nat, 2)
+xs: Vector<Nat, n>
+ys: Vector<Nat, 2>
 ```
 
 Take a moment to make sure the above makes sense to you. If you want to, you may

--- a/base/App.kind
+++ b/base/App.kind
@@ -2,6 +2,6 @@ type App <S: Type> {
   new(
     init: S,
     draw: S -> App.Render,
-    when: App.Event -> S -> List(App.Action(S))
+    when: App.Event -> S -> List<App.Action<S>>
   )
 }

--- a/base/App/Event.kind
+++ b/base/App/Event.kind
@@ -2,13 +2,13 @@ type App.Event {
   init(
     time: U64,
     addr: String,
-    screen: Pair(U32,U32),
-    mouse: Pair(U32,U32),
+    screen: Pair<U32,U32>,
+    mouse: Pair<U32,U32>,
   )
   tick(
     time: U64,
-    screen: Pair(U32,U32),
-    mouse: Pair(U32,U32),
+    screen: Pair<U32,U32>,
+    mouse: Pair<U32,U32>,
   )
   xkey(
     time: U64,

--- a/base/Array.kind
+++ b/base/Array.kind
@@ -1,4 +1,4 @@
 type Array<A: Type> ~ (depth: Nat) {
   tip(value: A)                                             ~ (depth = Nat.zero),
-  tie<depth: Nat>(lft: Array(A,depth), rgt: Array(A,depth)) ~ (depth = Nat.succ(depth))
+  tie<depth: Nat>(lft: Array<A,depth>, rgt: Array<A,depth>) ~ (depth = Nat.succ(depth))
 }

--- a/base/Array/alloc.kind
+++ b/base/Array/alloc.kind
@@ -1,7 +1,7 @@
-Array.alloc<A: Type>(depth: Nat, x: A): Array(A, depth)
+Array.alloc<A: Type>(depth: Nat, x: A): Array<A, depth>
   case depth {
     zero: Array.tip<A>(x),
     succ:
       let half = Array.alloc<A>(depth.pred, x)
       Array.tie<A, depth.pred>(half, half)
-  } : Array(A, depth)
+  } : Array<A, depth>

--- a/base/Array/extract_tie.kind
+++ b/base/Array/extract_tie.kind
@@ -1,8 +1,8 @@
-Array.extract_tie<A: Type, depth: Nat>(arr: Array(A,Nat.succ(depth))): Pair(Array(A,depth), Array(A,depth))
+Array.extract_tie<A: Type, depth: Nat>(arr: Array<A,Nat.succ(depth)>): Pair<Array<A,depth>, Array<A,depth>>
   case arr {
     tip: Unit.new,
     tie: Pair.new!!(arr.lft, arr.rgt)
   } : case arr.depth {
         zero: Unit,
-        succ: Pair(Array(A,arr.depth.pred), Array(A,arr.depth.pred))
+        succ: Pair<Array<A,arr.depth.pred>, Array<A,arr.depth.pred>>
       }

--- a/base/Array/extract_tip.kind
+++ b/base/Array/extract_tip.kind
@@ -1,4 +1,4 @@
-Array.extract_tip<A: Type>(arr: Array(A,0)): A
+Array.extract_tip<A: Type>(arr: Array<A,0>): A
   case arr {
     tip: arr.value,
     tie: Unit.new

--- a/base/Array/get.kind
+++ b/base/Array/get.kind
@@ -1,5 +1,5 @@
-Array.get<A:Type, depth:Nat>(idx: Word(depth), arr: Array(A,depth)): A
-  def P = (depth) Array(A,depth) -> A
+Array.get<A:Type, depth:Nat>(idx: Word(depth), arr: Array<A,depth>): A
+  def P = (depth) Array<A,depth> -> A
   def nil = Array.extract_tip<A>
   def w0 = <idx.size> (rec) (arr)
     let arr_l = Array.extract_tie<A, idx.size>(arr)

--- a/base/Array/mut.kind
+++ b/base/Array/mut.kind
@@ -1,6 +1,6 @@
 // Given array `arr`, little-endian word `idx` and function `f`, assigns `arr[idx] = f(arr[idx])`.
-Array.mut<A:Type, depth:Nat>(idx: Word(depth), f: A -> A, arr: Array(A,depth)): Array(A,depth)
-  def P = (depth) Array(A,depth) -> Array(A,depth)
+Array.mut<A:Type, depth:Nat>(idx: Word(depth), f: A -> A, arr: Array<A,depth>): Array<A,depth>
+  def P = (depth) Array<A,depth> -> Array<A,depth>
   def nil = (arr) Array.tip<A>(f(Array.extract_tip<A>(arr)))
   def w0 = <idx.size> (rec) (arr)
     let {arr_l,arr_r} = Array.extract_tie<A, idx.size>(arr)

--- a/base/Array/set.kind
+++ b/base/Array/set.kind
@@ -1,3 +1,3 @@
-Array.set<A:Type, depth:Nat>(idx: Word(depth), val: A, arr: Array(A,depth))
-: Array(A,depth)
+Array.set<A:Type, depth:Nat>(idx: Word(depth), val: A, arr: Array<A,depth>)
+: Array<A,depth>
   Array.mut<A,depth>(idx, (x) val, arr)

--- a/base/Bits/chunks_of.kind
+++ b/base/Bits/chunks_of.kind
@@ -1,2 +1,2 @@
-Bits.chunks_of(len: Nat, bits: Bits): List(Bits)
+Bits.chunks_of(len: Nat, bits: Bits): List<Bits>
   Bits.chunks_of.go(len, bits, len, Bits.e)

--- a/base/Bits/chunks_of/go.kind
+++ b/base/Bits/chunks_of/go.kind
@@ -3,7 +3,7 @@ Bits.chunks_of.go(
   bits  : Bits, // bits to be split
   need  : Nat,  // number of vals to complete chunk
   chunk : Bits  // current chunk
-) : List(Bits)
+) : List<Bits>
   case bits {
     e: List.cons!(Bits.reverse(chunk), List.nil!),
     o: case need {

--- a/base/BitsMap.kind
+++ b/base/BitsMap.kind
@@ -1,4 +1,4 @@
 type BitsMap <A: Type> {
   new,
-  tie(val: Maybe(A), lft: BitsMap(A), rgt: BitsMap(A)),
+  tie(val: Maybe<A>, lft: BitsMap<A>, rgt: BitsMap<A>),
 }

--- a/base/BitsMap/Row.kind
+++ b/base/BitsMap/Row.kind
@@ -1,5 +1,5 @@
-BitsMap.Row(A : Type,key: Bits, x: A, xs: BitsMap(A)) : Type
+BitsMap.Row(A : Type,key: Bits, x: A, xs: BitsMap<A>) : Type
   case BitsMap.get<A>(key,xs) as v {
     none: Empty,
-    some: Equal(A,x,v.value)
+    some: Equal<A,x,v.value>
   }

--- a/base/BitsMap/delete.kind
+++ b/base/BitsMap/delete.kind
@@ -1,4 +1,4 @@
-BitsMap.delete<A: Type>(key: Bits, map: BitsMap(A)): BitsMap(A)
+BitsMap.delete<A: Type>(key: Bits, map: BitsMap<A>): BitsMap<A>
   case map {
     new: BitsMap.new!,
     tie: case key {

--- a/base/BitsMap/disj.kind
+++ b/base/BitsMap/disj.kind
@@ -1,4 +1,4 @@
-BitsMap.disj<A: Type>(a: BitsMap(A), b: BitsMap(A)): Bool
+BitsMap.disj<A: Type>(a: BitsMap<A>, b: BitsMap<A>): Bool
   case a {
     new: Bool.true,
     tie: case b {

--- a/base/BitsMap/fold.kind
+++ b/base/BitsMap/fold.kind
@@ -1,4 +1,4 @@
-BitsMap.fold<A: Type>(map: BitsMap(A)): <P: Type> -> P -> (Maybe(A) -> P -> P -> P) -> P
+BitsMap.fold<A: Type>(map: BitsMap<A>): <P: Type> -> P -> (Maybe<A> -> P -> P -> P) -> P
   <P> (new, tie)
   case map {
     new: new,

--- a/base/BitsMap/from_list.kind
+++ b/base/BitsMap/from_list.kind
@@ -1,4 +1,4 @@
-BitsMap.from_list<A: Type>(xs: List(Pair(Bits,A))): BitsMap(A)
+BitsMap.from_list<A: Type>(xs: List<Pair<Bits,A>>): BitsMap<A>
   case xs {
     nil : BitsMap.new!,
     cons: case xs.head as p {

--- a/base/BitsMap/get.kind
+++ b/base/BitsMap/get.kind
@@ -1,4 +1,4 @@
-BitsMap.get<A: Type>(bits: Bits, map: BitsMap(A)): Maybe(A)
+BitsMap.get<A: Type>(bits: Bits, map: BitsMap<A>): Maybe<A>
   case bits {
     e: case map {
       new: Maybe.none!,

--- a/base/BitsMap/keys.kind
+++ b/base/BitsMap/keys.kind
@@ -1,2 +1,2 @@
-BitsMap.keys<A: Type>(xs: BitsMap(A)): List(Bits)
+BitsMap.keys<A: Type>(xs: BitsMap<A>): List<Bits>
   List.reverse!(BitsMap.keys.go!(xs, Bits.e, List.nil!))

--- a/base/BitsMap/keys/go.kind
+++ b/base/BitsMap/keys/go.kind
@@ -1,4 +1,4 @@
-BitsMap.keys.go<A: Type>(xs: BitsMap(A), key: Bits, list: List(Bits)): List(Bits)
+BitsMap.keys.go<A: Type>(xs: BitsMap<A>, key: Bits, list: List<Bits>): List<Bits>
   case xs {
     new:
       list,

--- a/base/BitsMap/map.kind
+++ b/base/BitsMap/map.kind
@@ -1,4 +1,4 @@
-BitsMap.map<A: Type, B: Type>(fn: A -> B, map: BitsMap(A)): BitsMap(B)
+BitsMap.map<A: Type, B: Type>(fn: A -> B, map: BitsMap<A>): BitsMap<B>
   case map {
     new: BitsMap.new!,
     tie:

--- a/base/BitsMap/merge.kind
+++ b/base/BitsMap/merge.kind
@@ -1,8 +1,8 @@
 BitsMap.merge<A: Type,B: Type,C: Type>(
-  a_not_b : Bits -> A -> Maybe(C),
-  b_not_a : Bits -> B -> Maybe(C),
-  a_and_b : Bits -> A -> B -> Maybe(C),
-  a: BitsMap(A),
-  b: BitsMap(B)
-) : BitsMap(C)
+  a_not_b : Bits -> A -> Maybe<C>,
+  b_not_a : Bits -> B -> Maybe<C>,
+  a_and_b : Bits -> A -> B -> Maybe<C>,
+  a: BitsMap<A>,
+  b: BitsMap<B>
+) : BitsMap<C>
   BitsMap.merge.go!!!(a_not_b,b_not_a,a_and_b,Bits.e,a,b)

--- a/base/BitsMap/merge/go.kind
+++ b/base/BitsMap/merge/go.kind
@@ -1,11 +1,11 @@
 BitsMap.merge.go<A: Type,B: Type,C: Type>(
-  f: Bits -> A -> Maybe(C),
-  g: Bits -> B -> Maybe(C),
-  h: Bits -> A -> B -> Maybe(C),
+  f: Bits -> A -> Maybe<C>,
+  g: Bits -> B -> Maybe<C>,
+  h: Bits -> A -> B -> Maybe<C>,
   key: Bits,
-  a: BitsMap(A),
-  b: BitsMap(B)
-) : BitsMap(C)
+  a: BitsMap<A>,
+  b: BitsMap<B>
+) : BitsMap<C>
   case a {
     new: case b {
       new: BitsMap.new!,

--- a/base/BitsMap/mut.kind
+++ b/base/BitsMap/mut.kind
@@ -1,4 +1,4 @@
-BitsMap.mut<A: Type>(bits: Bits, ini: A, fun: A -> A, map: BitsMap(A)): BitsMap(A)
+BitsMap.mut<A: Type>(bits: Bits, ini: A, fun: A -> A, map: BitsMap<A>): BitsMap<A>
   case bits {
     e: case map {
       new: BitsMap.tie!(Maybe.some!(ini), BitsMap.new!, BitsMap.new!),

--- a/base/BitsMap/query.kind
+++ b/base/BitsMap/query.kind
@@ -1,4 +1,4 @@
-BitsMap.query<A: Type>(cpy: A -> Pair(A, A), bits: Bits, map: BitsMap(A)): Pair(BitsMap(A), Maybe(A))
+BitsMap.query<A: Type>(cpy: A -> Pair<A, A>, bits: Bits, map: BitsMap<A>): Pair<BitsMap<A>, Maybe<A>>
   case bits {
   e: case map {
     new: 

--- a/base/BitsMap/set.kind
+++ b/base/BitsMap/set.kind
@@ -1,4 +1,4 @@
-BitsMap.set<A: Type>(bits: Bits, val: A, map: BitsMap(A)): BitsMap(A)
+BitsMap.set<A: Type>(bits: Bits, val: A, map: BitsMap<A>): BitsMap<A>
   case bits {
     e: case map {
       new: BitsMap.tie!(Maybe.some!(val), BitsMap.new!, BitsMap.new!),

--- a/base/BitsMap/to_list.kind
+++ b/base/BitsMap/to_list.kind
@@ -1,2 +1,2 @@
-BitsMap.to_list<A: Type>(xs: BitsMap(A)): List(Pair(Bits,A))
+BitsMap.to_list<A: Type>(xs: BitsMap<A>): List<Pair<Bits,A>>
   List.reverse!(BitsMap.to_list.go!(xs, Bits.e, List.nil!))

--- a/base/BitsMap/to_list/go.kind
+++ b/base/BitsMap/to_list/go.kind
@@ -1,4 +1,4 @@
-BitsMap.to_list.go<A: Type>(xs: BitsMap(A), key: Bits, list: List(Pair(Bits,A))): List(Pair(Bits,A))
+BitsMap.to_list.go<A: Type>(xs: BitsMap<A>, key: Bits, list: List<Pair<Bits,A>>): List<Pair<Bits,A>>
   case xs {
     new:
       list,

--- a/base/BitsMap/union.kind
+++ b/base/BitsMap/union.kind
@@ -1,4 +1,4 @@
-BitsMap.union<A: Type>(a: BitsMap(A), b: BitsMap(A)): BitsMap(A)
+BitsMap.union<A: Type>(a: BitsMap<A>, b: BitsMap<A>): BitsMap<A>
   case a {
     new: b,
     tie: case b {

--- a/base/BitsMap/values.kind
+++ b/base/BitsMap/values.kind
@@ -1,2 +1,2 @@
-BitsMap.values<A: Type>(xs: BitsMap(A)): List(A)
+BitsMap.values<A: Type>(xs: BitsMap<A>): List<A>
   BitsMap.values.go<A>(xs, List.nil!)

--- a/base/BitsMap/values/go.kind
+++ b/base/BitsMap/values/go.kind
@@ -1,4 +1,4 @@
-BitsMap.values.go<A: Type>(xs: BitsMap(A), list: List(A)): List(A)
+BitsMap.values.go<A: Type>(xs: BitsMap<A>, list: List<A>): List<A>
   case xs {
     new:
       list,

--- a/base/BitsSet.kind
+++ b/base/BitsSet.kind
@@ -1,2 +1,2 @@
 BitsSet: Type
-  BitsMap(Unit)
+  BitsMap<Unit>

--- a/base/Bool/double_negation.kind
+++ b/base/Bool/double_negation.kind
@@ -1,5 +1,5 @@
-Bool.double_negation(b: Bool): Equal(Bool, Bool.not(Bool.not(b)), b)
+Bool.double_negation(b: Bool): Equal<Bool, Bool.not(Bool.not(b)), b>
   case b {
     true: Equal.refl<_, Bool.true>,
     false: Equal.refl<_, Bool.false>,
-  } : Equal(Bool, Bool.not(Bool.not(b)), b)
+  } : Equal<Bool, Bool.not(Bool.not(b)), b>

--- a/base/Bool/equal/either.kind
+++ b/base/Bool/equal/either.kind
@@ -1,4 +1,4 @@
-Bool.equal.either(a: Bool, b: Bool): Either(a == b, a == Bool.not(b))
+Bool.equal.either(a: Bool, b: Bool): Either<a == b, a == Bool.not(b)>
   case a {
     true:
       case b {

--- a/base/Buffer32.kind
+++ b/base/Buffer32.kind
@@ -1,3 +1,3 @@
 type Buffer32 {
-  new(depth: Nat, array: Array(U32, depth))
+  new(depth: Nat, array: Array<U32, depth>)
 }

--- a/base/Either/bind.kind
+++ b/base/Either/bind.kind
@@ -1,4 +1,4 @@
-Either.bind<A: Type, B: Type, C: Type>(e: Either(A,B), f: B -> Either(A,C)): Either(A,C)
+Either.bind<A: Type, B: Type, C: Type>(e: Either<A,B>, f: B -> Either<A,C>): Either<A,C>
   case e {
     left: Either.left!!(e.value),
     right: f(e.value),

--- a/base/Either/functor.kind
+++ b/base/Either/functor.kind
@@ -1,2 +1,2 @@
-Either.functor<A: Type>: Functor(Either(A))
-  Functor.new<Either(A)>(Either.map<A>)
+Either.functor<A: Type>: Functor<Either<A>>
+  Functor.new<Either<A>>(Either.map<A>)

--- a/base/Either/map.kind
+++ b/base/Either/map.kind
@@ -1,4 +1,4 @@
-Either.map<A: Type, B: Type, C: Type>(f: B -> C, e: Either(A, B)): Either(A, C)
+Either.map<A: Type, B: Type, C: Type>(f: B -> C, e: Either<A, B>): Either<A, C>
   case e {
     left: Either.left<A, C>(e.value),
     right: Either.right<A, C>(f(e.value)),

--- a/base/Either/monad.kind
+++ b/base/Either/monad.kind
@@ -1,2 +1,2 @@
-Either.monad<A: Type>: Monad(Either(A))
-  Monad.new<Either(A)>(Either.bind<A>, Either.right<A>)
+Either.monad<A: Type>: Monad<Either<A>>
+  Monad.new<Either<A>>(Either.bind<A>, Either.right<A>)

--- a/base/Equal/apply.kind
+++ b/base/Equal/apply.kind
@@ -4,10 +4,10 @@ Equal.apply<
   a: A,
   b: A,
   f: A -> B
->(e: Equal(A,a,b)): Equal(B, f(a), f(b))
+>(e: Equal<A,a,b>): Equal<B, f(a), f(b)>
   case e {
     refl: Equal.refl<B, f(a)>
-  } : Equal(B, f(a), f(e.b))
+  } : Equal<B, f(a), f(e.b)>
 
 
 

--- a/base/Equal/cast.kind
+++ b/base/Equal/cast.kind
@@ -1,4 +1,4 @@
-Equal.cast<A: Type, a: A, b: A, P: A -> Type, e: Equal(A,a,b)>(x: P(a)): P(b)
+Equal.cast<A: Type, a: A, b: A, P: A -> Type, e: Equal<A,a,b>>(x: P(a)): P(b)
   case e{
     refl: x
   } : P(e.b)

--- a/base/Equal/chain.kind
+++ b/base/Equal/chain.kind
@@ -1,7 +1,7 @@
 Equal.chain<A: Type, a: A, b: A, c: A>(
-  d: Equal(A,a,b),
-  e: Equal(A,b,c)
-): Equal(A,a,c)
+  d: Equal<A,a,b>,
+  e: Equal<A,b,c>
+): Equal<A,a,c>
   case e {
     refl: d
-  } : Equal(A, a, e.b)
+  } : Equal<A, a, e.b>

--- a/base/Equal/left.kind
+++ b/base/Equal/left.kind
@@ -1,3 +1,3 @@
-Equal.left<A: Type, x: A, a: A, b: A>(r: Equal(A, a, x), s: Equal(A, b, x))
-: Equal(A, a, b)
+Equal.left<A: Type, x: A, a: A, b: A>(r: Equal<A, a, x>, s: Equal<A, b, x>)
+: Equal<A, a, b>
   Equal.chain<A, a, x, b>(r, Equal.mirror<A, b, x>(s))

--- a/base/Equal/mirror.kind
+++ b/base/Equal/mirror.kind
@@ -1,4 +1,4 @@
-Equal.mirror<A: Type, a: A, b: A>(e: Equal(A, a, b)): Equal(A, b, a)
+Equal.mirror<A: Type, a: A, b: A>(e: Equal<A, a, b>): Equal<A, b, a>
   case e {
     refl: Equal.refl<A, a>
-  } : Equal(A, e.b, a)
+  } : Equal<A, e.b, a>

--- a/base/Equal/rewrite.kind
+++ b/base/Equal/rewrite.kind
@@ -1,4 +1,4 @@
-Equal.rewrite<A: Type, a: A, b: A>(e: Equal(A,a,b))<P: A -> Type>(x: P(a)): P(b)
+Equal.rewrite<A: Type, a: A, b: A>(e: Equal<A,a,b>)<P: A -> Type>(x: P(a)): P(b)
   case e {
     refl: x
   } : P(e.b)

--- a/base/Equal/right.kind
+++ b/base/Equal/right.kind
@@ -1,3 +1,3 @@
-Equal.right<A: Type, x: A, a: A, b: A>(r: Equal(A, x, a), s: Equal(A, x, b))
-: Equal(A, a, b)
+Equal.right<A: Type, x: A, a: A, b: A>(r: Equal<A, x, a>, s: Equal<A, x, b>)
+: Equal<A, a, b>
   Equal.chain<A, a, x, b>(Equal.mirror<A, x, a>(r), s)

--- a/base/Example/monads.kind
+++ b/base/Example/monads.kind
@@ -1,5 +1,5 @@
 // Asks the user name forever
-Example.monads.hello: IO(Unit)
+Example.monads.hello: IO<Unit>
   IO {
     IO.print("What is your name?")
     var name = IO.get_line
@@ -8,14 +8,14 @@ Example.monads.hello: IO(Unit)
   }
 
 // Prints a random numbers
-Example.monads.random: IO(Unit)
+Example.monads.random: IO<Unit>
   IO {
     get seed = IO.get_time
     IO.print(Nat.show(Nat.random(seed)))
   }
 
 // This will return none if you attempt to access the list out of bound
-Example.monads.maybe: Maybe(Nat)
+Example.monads.maybe: Maybe<Nat>
   let list = [1, 2, 3]
   Maybe {
     get a = list[0]

--- a/base/Example/tesla_filter.kind
+++ b/base/Example/tesla_filter.kind
@@ -2,9 +2,9 @@
 // Suggested by Tesla Zhang
 
 Example.tesla_filter.go<A: Type, P: A -> Type>(
-  cond: (a: A) Decidable(P(a)),
-  list: List(A)
-): List(A)
+  cond: (a: A) Decidable<P(a)>,
+  list: List<A>
+): List<A>
   case list {
     nil: []
     cons: case cond(list.head) {
@@ -13,5 +13,5 @@ Example.tesla_filter.go<A: Type, P: A -> Type>(
     }!
   }!
 
-Example.tesla_filter: List(Nat)
+Example.tesla_filter: List<Nat>
   Example.tesla_filter.go!<(a) 4 == a>(Nat.is_equal(4), [1,2,3,4,5])

--- a/base/F64/Boundary.kind
+++ b/base/F64/Boundary.kind
@@ -1,3 +1,3 @@
 type F64.Boundary {
-  new(pts: List(F64.V3))
+  new(pts: List<F64.V3>)
 }

--- a/base/F64/V3/polygon_to_segments.kind
+++ b/base/F64/V3/polygon_to_segments.kind
@@ -1,9 +1,9 @@
 F64.V3.polygon_to_segments(
   pos: F64.V3,
   dir: F64.V3,
-  pts: List(F64.V3)):
-  List(F64.Segment)
-  List.foldr<F64.V3><Maybe(F64.V3) -> Maybe(F64.V3) -> List(F64.Segment)>(
+  pts: List<F64.V3>):
+  List<F64.Segment>
+  List.foldr<F64.V3><Maybe<F64.V3> -> Maybe<F64.V3> -> List<F64.Segment>>(
     F64.V3.polygon_to_segments.nil(pos, dir),
     F64.V3.polygon_to_segments.cons(pos, dir),
     pts,

--- a/base/F64/V3/polygon_to_segments/cons.kind
+++ b/base/F64/V3/polygon_to_segments/cons.kind
@@ -2,10 +2,10 @@ F64.V3.polygon_to_segments.cons(
   pos: F64.V3,
   dir: F64.V3,
   pt_b: F64.V3,
-  segs: (Maybe(F64.V3) -> Maybe(F64.V3) -> List(F64.Segment)),
-  pt_a: Maybe(F64.V3),
-  pt_0: Maybe(F64.V3)):
-  List(F64.Segment)
+  segs: (Maybe<F64.V3> -> Maybe<F64.V3> -> List<F64.Segment>),
+  pt_a: Maybe<F64.V3>,
+  pt_0: Maybe<F64.V3>):
+  List<F64.Segment>
   case pt_a {
    none: segs(Maybe.some<F64.V3>(pt_b), Maybe.some<F64.V3>(pt_b)),
    some:

--- a/base/F64/V3/polygon_to_segments/nil.kind
+++ b/base/F64/V3/polygon_to_segments/nil.kind
@@ -1,9 +1,9 @@
 F64.V3.polygon_to_segments.nil(
   pos: F64.V3,
   dir: F64.V3,
-  pt_a: Maybe(F64.V3),
-  pt_0: Maybe(F64.V3)):
-  List(F64.Segment)
+  pt_a: Maybe<F64.V3>,
+  pt_0: Maybe<F64.V3>):
+  List<F64.Segment>
   case pt_0 {
    none: List.nil<F64.Segment>,
    some: case pt_a {

--- a/base/F64/rotate2d.kind
+++ b/base/F64/rotate2d.kind
@@ -1,4 +1,4 @@
-F64.rotate2d(x: F64, y: F64, a: F64): Pair(F64, F64)
+F64.rotate2d(x: F64, y: F64, a: F64): Pair<F64, F64>
   let x2 = F64.sub(F64.mul(x, F64.cos(a)), F64.mul(y, F64.sin(a)))
   let y2 = F64.add(F64.mul(x, F64.sin(a)), F64.mul(y, F64.cos(a)))
   Pair.new!!(x2, y2)

--- a/base/Fin.kind
+++ b/base/Fin.kind
@@ -1,4 +1,4 @@
 type Fin ~ <lim: Nat> {
   zero<n: Nat>               ~ (lim = Nat.succ(n))
-  succ<n: Nat>(pred: Fin(n)) ~ (lim = Nat.succ(n))
+  succ<n: Nat>(pred: Fin<n>) ~ (lim = Nat.succ(n))
 }

--- a/base/Fmt/sprintf.kind
+++ b/base/Fmt/sprintf.kind
@@ -41,7 +41,7 @@ Fmt.Parser.char: Parser(Fmt.Specifier)
     return Fmt.Specifier.char(c);
   }
 
-Fmt.Parser.parser(xs: List(Fmt.Specifier)): Parser(List(Fmt.Specifier))
+Fmt.Parser.parser(xs: List<Fmt.Specifier>): Parser(List<Fmt.Specifier>)
   Parser {
     var stop = Parser.is_eof;
     if stop then Parser {
@@ -57,7 +57,7 @@ Fmt.Parser.parser(xs: List(Fmt.Specifier)): Parser(List(Fmt.Specifier))
     }
   }
 
-Fmt.Parser.parse(input: String): List(Fmt.Specifier)
+Fmt.Parser.parse(input: String): List<Fmt.Specifier>
   case Fmt.Parser.parser([], 0, input) as parsed {
     error: []
     value: parsed.val
@@ -67,7 +67,7 @@ Fmt.Parser.parse(input: String): List(Fmt.Specifier)
 // format string, for example, "%d is %d" would evaluate to
 // Nat -> Nat -> String - i.e. the formatter that takes two Nats and returns
 // the formatted String.
-Fmt.arguments(format: List(Fmt.Specifier)): Type
+Fmt.arguments(format: List<Fmt.Specifier>): Type
   case format {
     nil: String // the final result is a String
     cons: case format.head {
@@ -77,7 +77,7 @@ Fmt.arguments(format: List(Fmt.Specifier)): Type
     }
   }
 
-Fmt.sprintf.go(str: String, xs: List(Fmt.Specifier)): Fmt.arguments(xs)
+Fmt.sprintf.go(str: String, xs: List<Fmt.Specifier>): Fmt.arguments(xs)
   case xs {
     nil: str
     cons: case xs.head {

--- a/base/Function/curry.kind
+++ b/base/Function/curry.kind
@@ -1,2 +1,2 @@
-Function.curry<A: Type, B: Type, C: Type>(f: Pair(A, B) -> C, x: A, y: B): C
+Function.curry<A: Type, B: Type, C: Type>(f: Pair<A, B> -> C, x: A, y: B): C
   f(Pair.new<A, B>(x, y))

--- a/base/Function/uncurry.kind
+++ b/base/Function/uncurry.kind
@@ -1,3 +1,3 @@
-Function.uncurry<A: Type, B: Type, C: Type>(f: A -> B -> C, p: Pair(A, B)): C
+Function.uncurry<A: Type, B: Type, C: Type>(f: A -> B -> C, p: Pair<A, B>): C
   open p 
   f(p.fst, p.snd)

--- a/base/Functor/const.kind
+++ b/base/Functor/const.kind
@@ -1,3 +1,3 @@
-Functor.const<F: Type -> Type>(f: Functor(F)): <A: Type, B: Type> -> A -> F(B) -> F(A)
+Functor.const<F: Type -> Type>(f: Functor<F>): <A: Type, B: Type> -> A -> F(B) -> F(A)
   <A, B> (a)
   Functor.map!(f)!!(Function.const!!(a))

--- a/base/Functor/map.kind
+++ b/base/Functor/map.kind
@@ -1,3 +1,3 @@
-Functor.map<F: Type -> Type>(f: Functor(F)): <A: Type, B: Type> -> (A -> B) -> F(A) -> F(B)
+Functor.map<F: Type -> Type>(f: Functor<F>): <A: Type, B: Type> -> (A -> B) -> F(A) -> F(B)
   open f
   f.map

--- a/base/GMap.kind
+++ b/base/GMap.kind
@@ -1,4 +1,4 @@
 type GMap <K: Type, V: Type> {
   tip,
-  bin(size: Nat, key: K, val: V, left: GMap(K,V), right: GMap(K,V))
+  bin(size: Nat, key: K, val: V, left: GMap<K,V>, right: GMap<K,V>)
 }

--- a/base/GMap/adjust.kind
+++ b/base/GMap/adjust.kind
@@ -2,8 +2,8 @@ GMap.adjust<K: Type, V: Type>(
   cmp : K -> K -> Cmp,
   f   : V -> V, 
   key : K, 
-  map : GMap(K,V) 
-) : GMap(K,V)
+  map : GMap<K,V> 
+) : GMap<K,V>
   GMap.adjust_with_key<K,V>(
     cmp,
     (k, v) f(v),

--- a/base/GMap/adjust_with_key.kind
+++ b/base/GMap/adjust_with_key.kind
@@ -2,8 +2,8 @@ GMap.adjust_with_key<K: Type, V: Type>(
   cmp : K -> K -> Cmp,
   f   : K -> V -> V, 
   k   : K, 
-  map : GMap(K,V) 
-) : GMap(K,V)
+  map : GMap<K,V> 
+) : GMap<K,V>
   case map {
    tip: map,
    bin:  

--- a/base/GMap/balance.kind
+++ b/base/GMap/balance.kind
@@ -1,4 +1,4 @@
-GMap.balance<K: Type, V: Type>(k: K, v: V, l: GMap(K,V), r: GMap(K,V)): GMap(K,V)
+GMap.balance<K: Type, V: Type>(k: K, v: V, l: GMap<K,V>, r: GMap<K,V>): GMap<K,V>
   let size_l             = GMap.size<K,V>(l)
   let size_r             = GMap.size<K,V>(r)
   let size_l_plus_size_r = Nat.add(size_l, size_r)

--- a/base/GMap/concat3.kind
+++ b/base/GMap/concat3.kind
@@ -2,9 +2,9 @@ GMap.concat3<K: Type, V: Type>(
   cmp  : K -> K -> Cmp, 
   key  : K,
   val  : V, 
-  left : GMap(K,V),
-  right: GMap(K,V) 
-) : GMap(K,V)
+  left : GMap<K,V>,
+  right: GMap<K,V> 
+) : GMap<K,V>
 
   case left {
     tip: case right {

--- a/base/GMap/delete_min.kind
+++ b/base/GMap/delete_min.kind
@@ -1,4 +1,4 @@
-GMap.delete_min<K: Type, V: Type>(map: GMap(K,V)): GMap(K,V)
+GMap.delete_min<K: Type, V: Type>(map: GMap<K,V>): GMap<K,V>
   case map {
     tip: map,
     bin: case map.left {

--- a/base/GMap/foldr.kind
+++ b/base/GMap/foldr.kind
@@ -1,2 +1,2 @@
-GMap.foldr<K: Type, V: Type, Z: Type>(f: V -> Z -> Z, z: Z, map : GMap(K,V)): Z
+GMap.foldr<K: Type, V: Type, Z: Type>(f: V -> Z -> Z, z: Z, map : GMap<K,V>): Z
   GMap.foldr.go<K,V,Z>(f, z, map)

--- a/base/GMap/foldr/go.kind
+++ b/base/GMap/foldr/go.kind
@@ -1,4 +1,4 @@
-GMap.foldr.go<K: Type, V: Type, Z: Type>(f: V -> Z -> Z, z: Z, map: GMap(K,V)): Z 
+GMap.foldr.go<K: Type, V: Type, Z: Type>(f: V -> Z -> Z, z: Z, map: GMap<K,V>): Z 
   case map {
     tip: z,
     bin:  

--- a/base/GMap/foldr_with_key.kind
+++ b/base/GMap/foldr_with_key.kind
@@ -1,2 +1,2 @@
-GMap.foldr_with_key<K: Type, V: Type, Z: Type>(f: K -> V -> Z -> Z, z: Z, map: GMap(K,V)): Z 
+GMap.foldr_with_key<K: Type, V: Type, Z: Type>(f: K -> V -> Z -> Z, z: Z, map: GMap<K,V>): Z 
   GMap.foldr_with_key.go<K,V,Z>(f, z, map)

--- a/base/GMap/foldr_with_key/go.kind
+++ b/base/GMap/foldr_with_key/go.kind
@@ -1,7 +1,7 @@
 GMap.foldr_with_key.go<K: Type, V: Type, Z: Type>(
   f   : K -> V -> Z -> Z, 
   z   : Z,
-  map : GMap(K,V) 
+  map : GMap<K,V> 
 ) : Z 
   case map {
     tip: z,

--- a/base/GMap/from_list.kind
+++ b/base/GMap/from_list.kind
@@ -1,5 +1,5 @@
 GMap.from_list<K: Type, V: Type>(
   cmp : K -> K -> Cmp, 
-  xs  : List(Pair(K,V))
-) : GMap(K,V)
+  xs  : List<Pair<K,V>>
+) : GMap<K,V>
   GMap.from_list.go<K,V>(cmp, GMap.tip<K,V>, xs)

--- a/base/GMap/from_list/go.kind
+++ b/base/GMap/from_list/go.kind
@@ -1,8 +1,8 @@
 GMap.from_list.go<K: Type, V: Type>(
   cmp : K -> K -> Cmp, 
-  acc : GMap(K,V), 
-  xs  : List(Pair(K,V))
-) : GMap(K,V) 
+  acc : GMap<K,V>, 
+  xs  : List<Pair<K,V>>
+) : GMap<K,V> 
   case xs {
     nil : acc,
     cons:  

--- a/base/GMap/insert.kind
+++ b/base/GMap/insert.kind
@@ -2,8 +2,8 @@ GMap.insert<K: Type, V: Type>(
   cmp : K -> K -> Cmp,
   key : K, 
   val : V, 
-  map : GMap(K,V)
-) : GMap(K,V)
+  map : GMap<K,V>
+) : GMap<K,V>
 
   case map {
     tip: GMap.singleton<K,V>(key, val),

--- a/base/GMap/is_balanced.kind
+++ b/base/GMap/is_balanced.kind
@@ -1,4 +1,4 @@
-GMap.is_balanced<K: Type, V: Type>(map: GMap(K,V)): Bool
+GMap.is_balanced<K: Type, V: Type>(map: GMap<K,V>): Bool
   case map {
     tip: Bool.true,
     bin:  

--- a/base/GMap/lookup.kind
+++ b/base/GMap/lookup.kind
@@ -1,4 +1,4 @@
-GMap.lookup<K: Type, V: Type>(cmp: K -> K -> Cmp, key: K, map: GMap(K,V)): Maybe(V)
+GMap.lookup<K: Type, V: Type>(cmp: K -> K -> Cmp, key: K, map: GMap<K,V>): Maybe<V>
   case map {
     tip: Maybe.none<V>,
     bin: case cmp(key, map.key) {

--- a/base/GMap/lookup_with_default.kind
+++ b/base/GMap/lookup_with_default.kind
@@ -2,7 +2,7 @@ GMap.lookup_with_default<K: Type, V: Type>(
   cmp : K -> K -> Cmp,
   key : K, 
   dft : V,
-  map : GMap(K,V)
+  map : GMap<K,V>
 ) : V
   case GMap.lookup<K,V>(cmp, key, map) as maybe_val {
     none: dft, 

--- a/base/GMap/map.kind
+++ b/base/GMap/map.kind
@@ -1,4 +1,4 @@
-GMap.map<K: Type, V: Type, Z: Type>(f: V -> Z, map: GMap(K,V)): GMap(K,Z)
+GMap.map<K: Type, V: Type, Z: Type>(f: V -> Z, map: GMap<K,V>): GMap<K,Z>
   case map {
     tip: GMap.tip<K,Z>,
     bin:  

--- a/base/GMap/member.kind
+++ b/base/GMap/member.kind
@@ -1,4 +1,4 @@
-GMap.member<K: Type, V: Type>(cmp: K -> K -> Cmp, key: K, map: GMap(K,V)): Bool
+GMap.member<K: Type, V: Type>(cmp: K -> K -> Cmp, key: K, map: GMap<K,V>): Bool
   case map {
     tip: Bool.false,
     bin: case cmp(key, map.key) {

--- a/base/GMap/min.kind
+++ b/base/GMap/min.kind
@@ -1,8 +1,8 @@
-GMap.min<K: Type, V: Type>(map: GMap(K,V)): Maybe(Pair(K,V))
+GMap.min<K: Type, V: Type>(map: GMap<K,V>): Maybe<Pair<K,V>>
   case map {
-    tip: Maybe.none<Pair(K,V)>,
+    tip: Maybe.none<Pair<K,V>>,
     bin: case map.left {
-      tip: Maybe.some<Pair(K,V)>(Pair.new<K,V>(map.key, map.val)),
+      tip: Maybe.some<Pair<K,V>>(Pair.new<K,V>(map.key, map.val)),
       bin: GMap.min<K,V>(map.left)
     }
   }

--- a/base/GMap/node.kind
+++ b/base/GMap/node.kind
@@ -1,4 +1,4 @@
-GMap.node<K: Type, V: Type>(key: K, val: V, left: GMap(K,V), right: GMap(K,V)): GMap(K,V)
+GMap.node<K: Type, V: Type>(key: K, val: V, left: GMap<K,V>, right: GMap<K,V>): GMap<K,V>
   let size_left  = GMap.size<K,V>(left)
   let size_right = GMap.size<K,V>(right)
   let new_size   = List.sum([1, size_left, size_right])

--- a/base/GMap/not_member.kind
+++ b/base/GMap/not_member.kind
@@ -1,2 +1,2 @@
-GMap.not_member<K: Type, V: Type>(cmp: K -> K -> Cmp, key: K, map: GMap(K,V)): Bool
+GMap.not_member<K: Type, V: Type>(cmp: K -> K -> Cmp, key: K, map: GMap<K,V>): Bool
   Bool.not(GMap.member<K,V>(cmp, key, map))

--- a/base/GMap/null.kind
+++ b/base/GMap/null.kind
@@ -1,4 +1,4 @@
-GMap.null<K: Type, V: Type>(map: GMap(K,V)): Bool
+GMap.null<K: Type, V: Type>(map: GMap<K,V>): Bool
   case map {
     tip: Bool.true,
     bin: Bool.false

--- a/base/GMap/show.kind
+++ b/base/GMap/show.kind
@@ -1,9 +1,9 @@
 GMap.show<K: Type, V: Type>(
   show_key: K -> String,
   show_val: V -> String,
-  map     : GMap(K,V)
+  map     : GMap<K,V>
 ): String
   let show_pair = Pair.show<K,V>(show_key, show_val)
   let kvs       = GMap.to_list<K,V>(map)
-  let kvs       = List.map<Pair(K,V), String>(show_pair, kvs)
+  let kvs       = List.map<Pair<K,V>, String>(show_pair, kvs)
   List.show<String>(String.show, kvs)

--- a/base/GMap/singleton.kind
+++ b/base/GMap/singleton.kind
@@ -1,2 +1,2 @@
-GMap.singleton<K: Type, V: Type>(key: K, val: V): GMap(K,V)
+GMap.singleton<K: Type, V: Type>(key: K, val: V): GMap<K,V>
   GMap.bin<K,V>(1, key, val, GMap.tip!!, GMap.tip!!)

--- a/base/GMap/size.kind
+++ b/base/GMap/size.kind
@@ -1,4 +1,4 @@
-GMap.size<K: Type, V: Type>(map: GMap(K,V)): Nat 
+GMap.size<K: Type, V: Type>(map: GMap<K,V>): Nat 
   case map {
     tip: 0,
     bin: map.size

--- a/base/GMap/split_gtn.kind
+++ b/base/GMap/split_gtn.kind
@@ -1,4 +1,4 @@
-GMap.split_gtn<K: Type, V: Type>(cmp: K -> K-> Cmp, cut: K, map: GMap(K,V)): GMap(K,V)
+GMap.split_gtn<K: Type, V: Type>(cmp: K -> K-> Cmp, cut: K, map: GMap<K,V>): GMap<K,V>
   case map {
     tip: map,
     bin: case cmp(cut, map.key) {

--- a/base/GMap/split_ltn.kind
+++ b/base/GMap/split_ltn.kind
@@ -1,4 +1,4 @@
-GMap.split_ltn<K: Type, V: Type>(cmp: K -> K-> Cmp, cut: K, map: GMap(K,V)): GMap(K,V)
+GMap.split_ltn<K: Type, V: Type>(cmp: K -> K-> Cmp, cut: K, map: GMap<K,V>): GMap<K,V>
   case map {
     tip: map,
     bin: case cmp(cut, map.key) {

--- a/base/GMap/tests/1.kind
+++ b/base/GMap/tests/1.kind
@@ -1,4 +1,4 @@
-GMap.tests.1 : IO(Unit)
+GMap.tests.1 : IO<Unit>
   let kvs = [
     Pair.new!!(1,"a")
     Pair.new!!(2,"b")

--- a/base/GMap/to_list.kind
+++ b/base/GMap/to_list.kind
@@ -1,6 +1,6 @@
-GMap.to_list<K: Type, V: Type>(map: GMap(K,V)): List(Pair(K,V))
-  GMap.foldr_with_key<K,V,List(Pair(K,V))>(
-    (k, v, kvs) List.cons<Pair(K,V)>(Pair.new<K,V>(k,v), kvs),
-    List.nil<Pair(K,V)>,
+GMap.to_list<K: Type, V: Type>(map: GMap<K,V>): List<Pair<K,V>>
+  GMap.foldr_with_key<K,V,List<Pair<K,V>>>(
+    (k, v, kvs) List.cons<Pair<K,V>>(Pair.new<K,V>(k,v), kvs),
+    List.nil<Pair<K,V>>,
     map
   )

--- a/base/GMap/union.kind
+++ b/base/GMap/union.kind
@@ -1,8 +1,8 @@
 GMap.union<K: Type, V: Type>(
   cmp  : K -> K -> Cmp,
-  map_a: GMap(K,V), 
-  map_b: GMap(K,V)
-) : GMap(K,V)
+  map_a: GMap<K,V>, 
+  map_b: GMap<K,V>
+) : GMap<K,V>
   
   case map_a {
     tip: case map_b {

--- a/base/GSet.kind
+++ b/base/GSet.kind
@@ -1,4 +1,4 @@
 type GSet <A: Type> {
   tip,
-  bin(size: Nat, val: A, left: GSet(A), right: GSet(A))
+  bin(size: Nat, val: A, left: GSet<A>, right: GSet<A>)
 }

--- a/base/GSet/balance.kind
+++ b/base/GSet/balance.kind
@@ -1,4 +1,4 @@
-GSet.balance<A: Type>(a: A, l: GSet(A), r: GSet(A)): GSet(A)
+GSet.balance<A: Type>(a: A, l: GSet<A>, r: GSet<A>): GSet<A>
   let size_l             = GSet.size!(l)
   let size_r             = GSet.size!(r)
   let size_l_plus_size_r = Nat.add(size_l, size_r)

--- a/base/GSet/concat3.kind
+++ b/base/GSet/concat3.kind
@@ -1,9 +1,9 @@
 GSet.concat3<A: Type>(
   cmp  : A -> A -> Cmp,
   val  : A,
-  left : GSet(A), 
-  right: GSet(A)
-) : GSet(A)
+  left : GSet<A>, 
+  right: GSet<A>
+) : GSet<A>
   case left {
     tip: case right {
       // trivial case, both trees are empty

--- a/base/GSet/delete_min.kind
+++ b/base/GSet/delete_min.kind
@@ -1,4 +1,4 @@
-GSet.delete_min<A: Type>(set: GSet(A)): GSet(A)
+GSet.delete_min<A: Type>(set: GSet<A>): GSet<A>
   case set {
     tip: set,
     bin: case set.left {

--- a/base/GSet/foldr.kind
+++ b/base/GSet/foldr.kind
@@ -1,2 +1,2 @@
-GSet.foldr<A: Type, B: Type>(f: A -> B -> B, b: B, set: GSet(A)): B 
+GSet.foldr<A: Type, B: Type>(f: A -> B -> B, b: B, set: GSet<A>): B 
   GSet.foldr.go!!(f, b, set)

--- a/base/GSet/foldr/go.kind
+++ b/base/GSet/foldr/go.kind
@@ -1,4 +1,4 @@
-GSet.foldr.go<A: Type, B: Type>(f: A -> B -> B, acc: B, set: GSet(A)): B 
+GSet.foldr.go<A: Type, B: Type>(f: A -> B -> B, acc: B, set: GSet<A>): B 
   case set {
     tip: acc,
     bin: 

--- a/base/GSet/from_list.kind
+++ b/base/GSet/from_list.kind
@@ -1,2 +1,2 @@
-GSet.from_list<A: Type>(cmp: A -> A -> Cmp, xs: List(A)): GSet(A)
+GSet.from_list<A: Type>(cmp: A -> A -> Cmp, xs: List<A>): GSet<A>
   List.foldr!!(GSet.tip!, GSet.insert!(cmp), xs)

--- a/base/GSet/insert.kind
+++ b/base/GSet/insert.kind
@@ -1,4 +1,4 @@
-GSet.insert<A: Type>(cmp: A -> A -> Cmp, a: A, set: GSet(A)): GSet(A)
+GSet.insert<A: Type>(cmp: A -> A -> Cmp, a: A, set: GSet<A>): GSet<A>
   case set {
     tip: GSet.singleton!(a),
     bin: case cmp(a, set.val) {

--- a/base/GSet/is_balanced.kind
+++ b/base/GSet/is_balanced.kind
@@ -1,4 +1,4 @@
-GSet.is_balanced<A: Type>(set: GSet(A)): Bool 
+GSet.is_balanced<A: Type>(set: GSet<A>): Bool 
   case set {
     tip: Bool.true,
     bin: 

--- a/base/GSet/is_singleton.kind
+++ b/base/GSet/is_singleton.kind
@@ -1,3 +1,3 @@
-GSet.is_singleton<A: Type>(set: GSet(A)): Bool
+GSet.is_singleton<A: Type>(set: GSet<A>): Bool
   let size = GSet.size!(set)
   if Nat.eql(size, 1) then Bool.true else Bool.false

--- a/base/GSet/map.kind
+++ b/base/GSet/map.kind
@@ -1,4 +1,4 @@
-GSet.map<A: Type, B: Type>(f: A -> B, set: GSet(A)): GSet(B)
+GSet.map<A: Type, B: Type>(f: A -> B, set: GSet<A>): GSet<B>
   case set {
     tip: GSet.tip!,
     bin: 

--- a/base/GSet/member.kind
+++ b/base/GSet/member.kind
@@ -1,4 +1,4 @@
-GSet.member<A: Type>(cmp: A -> A -> Cmp, a: A, set: GSet(A)): Bool
+GSet.member<A: Type>(cmp: A -> A -> Cmp, a: A, set: GSet<A>): Bool
   case set {
     tip: Bool.false,
     bin: case cmp(a, set.val) {

--- a/base/GSet/members.kind
+++ b/base/GSet/members.kind
@@ -1,2 +1,2 @@
-GSet.members<A: Type>(set: GSet(A)): List(A)
+GSet.members<A: Type>(set: GSet<A>): List<A>
   GSet.foldr!!(List.cons!, List.nil!, set)

--- a/base/GSet/min.kind
+++ b/base/GSet/min.kind
@@ -1,4 +1,4 @@
-GSet.min<A: Type>(set: GSet(A)): Maybe(A)
+GSet.min<A: Type>(set: GSet<A>): Maybe<A>
   case set {
     tip: Maybe.none!,
     bin: case set.left {

--- a/base/GSet/node.kind
+++ b/base/GSet/node.kind
@@ -1,4 +1,4 @@
-GSet.node<A: Type>(val: A, left: GSet(A), right: GSet(A)): GSet(A)
+GSet.node<A: Type>(val: A, left: GSet<A>, right: GSet<A>): GSet<A>
   let size_left  = GSet.size!(left)
   let size_right = GSet.size!(right)
   let new_size   = List.sum([1, size_left, size_right])

--- a/base/GSet/not_member.kind
+++ b/base/GSet/not_member.kind
@@ -1,2 +1,2 @@
-GSet.not_member<A: Type>(cmp: A -> A -> Cmp, a: A, set: GSet(A)): Bool
+GSet.not_member<A: Type>(cmp: A -> A -> Cmp, a: A, set: GSet<A>): Bool
   Bool.not(GSet.member!(cmp, a, set))

--- a/base/GSet/null.kind
+++ b/base/GSet/null.kind
@@ -1,4 +1,4 @@
-GSet.null<A: Type>(set: GSet(A)): Bool
+GSet.null<A: Type>(set: GSet<A>): Bool
   case set {
     tip: Bool.true,
     bin: Bool.false

--- a/base/GSet/show.kind
+++ b/base/GSet/show.kind
@@ -1,2 +1,2 @@
-GSet.show<A: Type>(to_str: A -> String, set: GSet(A)): String
+GSet.show<A: Type>(to_str: A -> String, set: GSet<A>): String
    List.show!(to_str, GSet.members!(set))

--- a/base/GSet/singleton.kind
+++ b/base/GSet/singleton.kind
@@ -1,2 +1,2 @@
-GSet.singleton<A: Type>(a: A): GSet(A)
+GSet.singleton<A: Type>(a: A): GSet<A>
   GSet.bin!(1, a, GSet.tip!, GSet.tip!)

--- a/base/GSet/size.kind
+++ b/base/GSet/size.kind
@@ -1,4 +1,4 @@
-GSet.size<A: Type>(set: GSet(A)): Nat 
+GSet.size<A: Type>(set: GSet<A>): Nat 
   case set {
     tip: 0,
     bin: set.size

--- a/base/GSet/split_gtn.kind
+++ b/base/GSet/split_gtn.kind
@@ -1,4 +1,4 @@
-GSet.split_gtn<A: Type>(cmp: A -> A -> Cmp, cut: A, set: GSet(A)): GSet(A)
+GSet.split_gtn<A: Type>(cmp: A -> A -> Cmp, cut: A, set: GSet<A>): GSet<A>
   case set {
     tip: set,
     bin: case cmp(cut, set.val) {

--- a/base/GSet/split_ltn.kind
+++ b/base/GSet/split_ltn.kind
@@ -1,4 +1,4 @@
-GSet.split_ltn<A: Type>(cmp: A -> A -> Cmp, cut: A, set: GSet(A)): GSet(A)
+GSet.split_ltn<A: Type>(cmp: A -> A -> Cmp, cut: A, set: GSet<A>): GSet<A>
   case set {
     tip: set,
     bin: case cmp(cut, set.val) {

--- a/base/GSet/to_list.kind
+++ b/base/GSet/to_list.kind
@@ -1,2 +1,2 @@
-GSet.to_list<A: Type>(set: GSet(A)): List(A)
+GSet.to_list<A: Type>(set: GSet<A>): List<A>
   GSet.members!(set)

--- a/base/GSet/union.kind
+++ b/base/GSet/union.kind
@@ -1,4 +1,4 @@
-GSet.union<A: Type>(cmp: A -> A -> Cmp, set_a: GSet(A), set_b: GSet(A)): GSet(A)
+GSet.union<A: Type>(cmp: A -> A -> Cmp, set_a: GSet<A>, set_b: GSet<A>): GSet<A>
   case set_a {
     tip: case set_b {
       tip: GSet.tip!,

--- a/base/IO.kind
+++ b/base/IO.kind
@@ -1,4 +1,4 @@
 type IO <A: Type> {
   end(value: A),
-  ask(query: String, param: String, then: (response: String) IO(A)),
+  ask(query: String, param: String, then: (response: String) IO<A>),
 }

--- a/base/IO/bind.kind
+++ b/base/IO/bind.kind
@@ -1,4 +1,4 @@
-IO.bind<A: Type, B: Type>(a: IO(A), f: A -> IO(B)): IO(B)
+IO.bind<A: Type, B: Type>(a: IO<A>, f: A -> IO<B>): IO<B>
   case a {
     end: f(a.value),
     ask: IO.ask<B>(a.query, a.param, (x) IO.bind<A,B>(a.then(x), f)),

--- a/base/IO/exit.kind
+++ b/base/IO/exit.kind
@@ -1,3 +1,3 @@
-IO.exit: IO(Unit)
+IO.exit: IO<Unit>
   IO.ask<Unit>("exit", "", (file)
   IO.end<Unit>(Unit.new))

--- a/base/IO/get_args.kind
+++ b/base/IO/get_args.kind
@@ -1,3 +1,3 @@
-IO.get_args: IO(String)
+IO.get_args: IO<String>
   IO.ask<String>("get_args", "", (line)
   IO.end<String>(line))

--- a/base/IO/get_file.kind
+++ b/base/IO/get_file.kind
@@ -1,3 +1,3 @@
-IO.get_file(name: String): IO(String)
+IO.get_file(name: String): IO<String>
   IO.ask<String>("get_file", name, (file)
   IO.end<String>(file))

--- a/base/IO/get_line.kind
+++ b/base/IO/get_line.kind
@@ -1,3 +1,3 @@
-IO.get_line: IO(String)
+IO.get_line: IO<String>
   IO.ask<String>("get_line", "", (line)
   IO.end<String>(line))

--- a/base/IO/get_time.kind
+++ b/base/IO/get_time.kind
@@ -1,3 +1,3 @@
-IO.get_time: IO(Nat)
+IO.get_time: IO<Nat>
   IO.ask<Nat>("get_time", "", (time)
   IO.end<Nat>(Nat.read(time)))

--- a/base/IO/monad.kind
+++ b/base/IO/monad.kind
@@ -1,2 +1,2 @@
-IO.monad: Monad(IO)
+IO.monad: Monad<IO>
   Monad.new<IO>(IO.bind, IO.end)

--- a/base/IO/print.kind
+++ b/base/IO/print.kind
@@ -1,2 +1,2 @@
-IO.print(text: String): IO(Unit)
+IO.print(text: String): IO<Unit>
   IO.put_string(text | "\n")

--- a/base/IO/prompt.kind
+++ b/base/IO/prompt.kind
@@ -1,4 +1,4 @@
-IO.prompt(text: String): IO(String)
+IO.prompt(text: String): IO<String>
   IO {
     IO.put_string(text)
     IO.get_line

--- a/base/IO/purify.kind
+++ b/base/IO/purify.kind
@@ -1,4 +1,4 @@
-IO.purify<A: Type>(io: IO(A)): A
+IO.purify<A: Type>(io: IO<A>): A
   case io {
     end: io.value,
     ask: IO.purify<A>(io.then("")),

--- a/base/IO/put_string.kind
+++ b/base/IO/put_string.kind
@@ -1,3 +1,3 @@
-IO.put_string(text: String): IO(Unit)
+IO.put_string(text: String): IO<Unit>
   IO.ask<Unit>("put_string", text, (skip)
   IO.end<Unit>(Unit.new))

--- a/base/IO/set_file.kind
+++ b/base/IO/set_file.kind
@@ -1,3 +1,3 @@
-IO.set_file(name: String, content: String): IO(Unit)
+IO.set_file(name: String, content: String): IO<Unit>
   IO.ask<Unit>("set_file", name | "=" | content, (ok)
   IO.end<Unit>(Unit.new))

--- a/base/Int/extract.kind
+++ b/base/Int/extract.kind
@@ -2,9 +2,9 @@ Int.extract<T: Type>(
   a: Nat,
   b: Nat,
   f: Nat -> Nat -> T,
-): Either(
+): Either<
   Int.new(a, b, (i) T, f) == f(0, Nat.sub(b,a)),
-  Int.new(a, b, (i) T, f) == f(Nat.sub(a,b), 0))
+  Int.new(a, b, (i) T, f) == f(Nat.sub(a,b), 0)>
   case a {
     zero: Either.left!!(refl)
     succ: case b {

--- a/base/Int/normalize.kind
+++ b/base/Int/normalize.kind
@@ -1,4 +1,4 @@
-Int.normalize(a: Nat, b: Nat): Either(Int.new(a,b) == Int.new(Nat.sub(a,b),0), Int.new(a,b) == Int.new(0,Nat.sub(b,a)))
+Int.normalize(a: Nat, b: Nat): Either<Int.new(a,b) == Int.new(Nat.sub(a,b),0), Int.new(a,b) == Int.new(0,Nat.sub(b,a))>
   case a {
     zero: Either.right!!(refl)
     succ: case b {

--- a/base/Int/to_nat.kind
+++ b/base/Int/to_nat.kind
@@ -1,4 +1,4 @@
-Int.to_nat(a: Int): Pair(Bool, Nat)
+Int.to_nat(a: Int): Pair<Bool, Nat>
   open a
   case a.y {
     zero: Pair.new!!(Bool.false, a.x),

--- a/base/JSON.kind
+++ b/base/JSON.kind
@@ -3,6 +3,6 @@ type JSON {
   bool(x: Bool),
   number(x: F64),
   string(x: String),
-  array(x: List(JSON)),
-  object(x: List(Pair(String, JSON)))
+  array(x: List<JSON>),
+  object(x: List<Pair<String, JSON>>)
 }

--- a/base/Kind/Check.kind
+++ b/base/Kind/Check.kind
@@ -1,6 +1,6 @@
 type Kind.Check<V: Type> {
   result(
-    value: Maybe(V), // the returned value
-    errors: List(Kind.Error), // a list of errors
+    value: Maybe<V>, // the returned value
+    errors: List<Kind.Error>, // a list of errors
   ),
 }

--- a/base/Kind/Check/bind.kind
+++ b/base/Kind/Check/bind.kind
@@ -1,4 +1,4 @@
-Kind.Check.bind<A: Type, B: Type>(a: Kind.Check(A), f: A -> Kind.Check(B)): Kind.Check(B)
+Kind.Check.bind<A: Type, B: Type>(a: Kind.Check<A>, f: A -> Kind.Check<B>): Kind.Check<B>
   case a {
     result: case a.value as got {
       none: Kind.Check.result<B>(Maybe.none<B>, a.errors)

--- a/base/Kind/Check/monad.kind
+++ b/base/Kind/Check/monad.kind
@@ -1,2 +1,2 @@
-Kind.Check.monad: Monad(Kind.Check)
+Kind.Check.monad: Monad<Kind.Check>
   Monad.new<Kind.Check>(Kind.Check.bind, Kind.Check.pure)

--- a/base/Kind/Check/none.kind
+++ b/base/Kind/Check/none.kind
@@ -1,2 +1,2 @@
-Kind.Check.none<A: Type>: Kind.Check(A)
+Kind.Check.none<A: Type>: Kind.Check<A>
   Kind.Check.result<A>(Maybe.none<A>, [])

--- a/base/Kind/Check/pure.kind
+++ b/base/Kind/Check/pure.kind
@@ -1,2 +1,2 @@
-Kind.Check.pure<V: Type>(value: V): Kind.Check(V)
+Kind.Check.pure<V: Type>(value: V): Kind.Check<V>
   Kind.Check.result<V>(Maybe.some<V>(value), [])

--- a/base/Kind/Check/value.kind
+++ b/base/Kind/Check/value.kind
@@ -1,3 +1,3 @@
-Kind.Check.value<A: Type>(chk: Kind.Check(A)): Maybe(A)
+Kind.Check.value<A: Type>(chk: Kind.Check<A>): Maybe<A>
   open chk
   chk.value

--- a/base/Kind/Code/escapes.kind
+++ b/base/Kind/Code/escapes.kind
@@ -1,4 +1,4 @@
-Kind.Code.escapes: List(Pair(String, Char))
+Kind.Code.escapes: List<Pair<String, Char>>
   [
     {"\\b" , '\b'},
     {"\\f" , '\f'},

--- a/base/Kind/Code/highlight.kind
+++ b/base/Kind/Code/highlight.kind
@@ -8,7 +8,7 @@ Kind.Code.highlight(
 Kind.Code.highlight.end(
   col: Nat,
   row: Nat,
-  res: List(String),
+  res: List<String>,
 ): String
   String.join("\n", res)
 
@@ -18,9 +18,9 @@ Kind.Code.highlight.go(
   ix1: Nat,
   col: Nat,
   row: Nat,
-  lft: Maybe(Nat),
+  lft: Maybe<Nat>,
   lin: String,
-  res: List(String),
+  res: List<String>,
 ): String
   //use skip = Debug.log!(String.flatten([
     //"ix0=", Nat.show(ix0), " ",

--- a/base/Kind/Constructor.kind
+++ b/base/Kind/Constructor.kind
@@ -1,7 +1,7 @@
 type Kind.Constructor {
   new(
     name: Kind.Name,
-    args: List(Kind.Binder),
-    inds: List(Kind.Binder),
+    args: List<Kind.Binder>,
+    inds: List<Kind.Binder>,
   )
 }

--- a/base/Kind/Constructor/build_term.kind
+++ b/base/Kind/Constructor/build_term.kind
@@ -7,8 +7,8 @@ Kind.Constructor.build_term.go(
   type: Kind.Datatype,
   ctor: Kind.Constructor,
   name: Kind.Name,
-  pars: List(Kind.Binder),
-  args: List(Kind.Binder),
+  pars: List<Kind.Binder>,
+  args: List<Kind.Binder>,
 ): Kind.Term
   case pars {
     cons: case pars.head {
@@ -38,7 +38,7 @@ Kind.Constructor.build_term.opt(type: Kind.Datatype, ctor: Kind.Constructor): Ki
 Kind.Constructor.build_term.opt.go(
   type: Kind.Datatype,
   ctor: Kind.Constructor,
-  ctrs: List(Kind.Constructor),
+  ctrs: List<Kind.Constructor>,
 ): Kind.Term
   case ctrs {
     cons: case ctrs.head {

--- a/base/Kind/Constructor/build_type.kind
+++ b/base/Kind/Constructor/build_type.kind
@@ -14,8 +14,8 @@ Kind.Constructor.build_type.go(
   type: Kind.Datatype,
   ctor: Kind.Constructor,
   name: Kind.Name,
-  pars: List(Kind.Binder),
-  args: List(Kind.Binder),
+  pars: List<Kind.Binder>,
+  args: List<Kind.Binder>,
 ): Kind.Term
   case pars {
     cons: case pars.head {

--- a/base/Kind/Context.kind
+++ b/base/Kind/Context.kind
@@ -1,2 +1,2 @@
 Kind.Context: Type
-  List(Pair(Kind.Name,Kind.Term))
+  List<Pair<Kind.Name,Kind.Term>>

--- a/base/Kind/Context/find.kind
+++ b/base/Kind/Context/find.kind
@@ -1,8 +1,8 @@
-Kind.Context.find(name: Kind.Name, ctx: Kind.Context): Maybe(Kind.Term)
+Kind.Context.find(name: Kind.Name, ctx: Kind.Context): Maybe<Kind.Term>
   let {name, skip} = Kind.Context.get_name_skips(name)
   Kind.Context.find.go(name, skip, ctx)
 
-Kind.Context.find.go(name: Kind.Name, skip: Nat, ctx: Kind.Context): Maybe(Kind.Term)
+Kind.Context.find.go(name: Kind.Name, skip: Nat, ctx: Kind.Context): Maybe<Kind.Term>
   case ctx {
     nil:
       none

--- a/base/Kind/Context/get_name_skips.kind
+++ b/base/Kind/Context/get_name_skips.kind
@@ -1,4 +1,4 @@
-Kind.Context.get_name_skips(name: Kind.Name): Pair(Kind.Name, Nat)
+Kind.Context.get_name_skips(name: Kind.Name): Pair<Kind.Name, Nat>
   //log("get_name_skips ", name)
   case name {
     nil: {"", 0}

--- a/base/Kind/Context/names.kind
+++ b/base/Kind/Context/names.kind
@@ -1,2 +1,2 @@
-Kind.Context.names(ctx: Kind.Context): List(Kind.Name)
+Kind.Context.names(ctx: Kind.Context): List<Kind.Name>
   List.mapped!(ctx)!((x) Pair.fst!!(x))

--- a/base/Kind/Core/read.kind
+++ b/base/Kind/Core/read.kind
@@ -6,7 +6,7 @@ Kind.Core.read.is_name(chr: Char): Bool
   Bool.or(Bool.and(U16.gte(chr,97s), U16.ltn(chr,123s)), // a-z
   Bool.false)))))
 
-Kind.Core.read.name(code: String): Pair(String, String)
+Kind.Core.read.name(code: String): Pair<String, String>
   case code {
     nil:
       {code, ""}
@@ -18,7 +18,7 @@ Kind.Core.read.name(code: String): Pair(String, String)
         {code, ""}
   }
   
-Kind.Core.read.spaces(code: String): Pair(String, Unit)
+Kind.Core.read.spaces(code: String): Pair<String, Unit>
   case code {
     nil:
       {code, unit}
@@ -37,7 +37,7 @@ Kind.Core.read.spaces(code: String): Pair(String, Unit)
         {code, unit}
   }
 
-Kind.Core.read.char(code: String, chr: Char): Pair(String, Unit)
+Kind.Core.read.char(code: String, chr: Char): Pair<String, Unit>
   let {code, skip} = Kind.Core.read.spaces(code)
   case code {
     nil:
@@ -49,7 +49,7 @@ Kind.Core.read.char(code: String, chr: Char): Pair(String, Unit)
         {"", unit} // unexpected character
   }
 
-Kind.Core.read.u16(code: String, u16: Char): Pair(String, Char)
+Kind.Core.read.u16(code: String, u16: Char): Pair<String, Char>
   case code {
     nil:
       {code, u16}
@@ -61,7 +61,7 @@ Kind.Core.read.u16(code: String, u16: Char): Pair(String, Char)
         {code, u16}
   }
 
-Kind.Core.read.natx(code: String, nat: Nat): Pair(String, Nat)
+Kind.Core.read.natx(code: String, nat: Nat): Pair<String, Nat>
   case code {
     nil:
       {code, nat}
@@ -73,7 +73,7 @@ Kind.Core.read.natx(code: String, nat: Nat): Pair(String, Nat)
         {code, nat}
   }
 
-Kind.Core.read.chrx(code: String): Pair(String, Char)
+Kind.Core.read.chrx(code: String): Pair<String, Char>
   if String.starts_with(code, "\\u{") then
     let code = String.drop(3, code)
     let {code, chrx} = Kind.Core.read.u16(code, 0s)
@@ -86,7 +86,7 @@ Kind.Core.read.chrx(code: String): Pair(String, Char)
     cons: {code.tail, code.head}
   }
         
-Kind.Core.read.strx(code: String): Pair(String, String)
+Kind.Core.read.strx(code: String): Pair<String, String>
   if String.starts_with(code, "\"") then
     {code, ""}
   else
@@ -94,7 +94,7 @@ Kind.Core.read.strx(code: String): Pair(String, String)
     let {code, rest} = Kind.Core.read.strx(code)
     {code, String.cons(chrx, rest)}
 
-Kind.Core.read.find<A: Type>(list: List(A), cond: A -> Nat -> Bool, indx: Nat, skip: Nat): Maybe(Pair(A,Nat))
+Kind.Core.read.find<A: Type>(list: List<A>, cond: A -> Nat -> Bool, indx: Nat, skip: Nat): Maybe<Pair<A,Nat>>
   case list {
     nil:
       none
@@ -108,7 +108,7 @@ Kind.Core.read.find<A: Type>(list: List(A), cond: A -> Nat -> Bool, indx: Nat, s
         Kind.Core.read.find!(list.tail, cond, Nat.succ(indx), skip)
   }
 
-Kind.Core.read.term(code: String): Pair(String, List(Pair(String,Kind.Term)) -> Kind.Term)
+Kind.Core.read.term(code: String): Pair<String, List<Pair<String,Kind.Term>> -> Kind.Term>
   //log(code)
   let {code, skip} = Kind.Core.read.spaces(code)
   case code {
@@ -195,7 +195,7 @@ Kind.Core.read.term(code: String): Pair(String, List(Pair(String,Kind.Term)) -> 
           {"", (ctx) Kind.Term.ref("error")}
   }
 
-Kind.Core.read(code: String): Maybe(Kind.Term)
+Kind.Core.read(code: String): Maybe<Kind.Term>
   let {code, term} = Kind.Core.read.term(code | ";")
   case code {
     nil: none

--- a/base/Kind/Core/show.kind
+++ b/base/Kind/Core/show.kind
@@ -1,4 +1,4 @@
-Kind.Core.show(term: Kind.Term, indx: Nat, vars: List(Kind.Name)): String
+Kind.Core.show(term: Kind.Term, indx: Nat, vars: List<Kind.Name>): String
   case term {
     ref:
       Kind.Name.show(term.name)

--- a/base/Kind/Core/var_name.kind
+++ b/base/Kind/Core/var_name.kind
@@ -1,4 +1,4 @@
-Kind.Core.var_name(indx: Nat, name: Kind.Name, brui: Nat, vars: List(Kind.Name)): Kind.Name
+Kind.Core.var_name(indx: Nat, name: Kind.Name, brui: Nat, vars: List<Kind.Name>): Kind.Name
   case indx {
     zero: case brui {
       zero: name

--- a/base/Kind/Datatype.kind
+++ b/base/Kind/Datatype.kind
@@ -1,8 +1,8 @@
 type Kind.Datatype {
   new(
     name: Kind.Name,
-    pars: List(Kind.Binder),
-    inds: List(Kind.Binder),
-    ctrs: List(Kind.Constructor),
+    pars: List<Kind.Binder>,
+    inds: List<Kind.Binder>,
+    ctrs: List<Kind.Constructor>,
   )
 }

--- a/base/Kind/Datatype/build_term.kind
+++ b/base/Kind/Datatype/build_term.kind
@@ -6,8 +6,8 @@ Kind.Datatype.build_term(type: Kind.Datatype): Kind.Term
 Kind.Datatype.build_term.go(
   type: Kind.Datatype,
   name: Kind.Name,
-  pars: List(Kind.Binder),
-  inds: List(Kind.Binder),
+  pars: List<Kind.Binder>,
+  inds: List<Kind.Binder>,
 ): Kind.Term
   case pars {
     cons:
@@ -35,7 +35,7 @@ Kind.Datatype.build_term.constructor(type: Kind.Datatype, ctor: Kind.Constructor
 Kind.Datatype.build_term.constructor.go(
   type: Kind.Datatype,
   ctor: Kind.Constructor,
-  args: List(Kind.Binder),
+  args: List<Kind.Binder>,
 ): Kind.Term
   case args {
     cons:
@@ -67,7 +67,7 @@ Kind.Datatype.build_term.constructors(type: Kind.Datatype): Kind.Term
 Kind.Datatype.build_term.constructors.go(
   type: Kind.Datatype,
   name: Kind.Name,
-  ctrs: List(Kind.Constructor),
+  ctrs: List<Kind.Constructor>,
 ): Kind.Term
   case ctrs {
     cons:
@@ -93,7 +93,7 @@ Kind.Datatype.build_term.motive(
 Kind.Datatype.build_term.motive.go(
   type: Kind.Datatype,
   name: Kind.Name,
-  inds: List(Kind.Binder),
+  inds: List<Kind.Binder>,
 ): Kind.Term
   case inds {
     cons:

--- a/base/Kind/Datatype/build_type.kind
+++ b/base/Kind/Datatype/build_type.kind
@@ -6,8 +6,8 @@ Kind.Datatype.build_type(type: Kind.Datatype): Kind.Term
 Kind.Datatype.build_type.go(
   type: Kind.Datatype,
   name: Kind.Name,
-  pars: List(Kind.Binder),
-  inds: List(Kind.Binder),
+  pars: List<Kind.Binder>,
+  inds: List<Kind.Binder>,
 ): Kind.Term
   case pars {
     cons: case pars.head {

--- a/base/Kind/Def.kind
+++ b/base/Kind/Def.kind
@@ -2,7 +2,7 @@ type Kind.Def {
   new(
     file: String,
     code: String,
-    orig: Pair(Nat, Nat),
+    orig: Pair<Nat, Nat>,
     name: Kind.Name,
     term: Kind.Term,
     type: Kind.Term,

--- a/base/Kind/Defs.kind
+++ b/base/Kind/Defs.kind
@@ -1,2 +1,2 @@
 Kind.Defs: Type
-  BitsMap(Kind.Def)
+  BitsMap<Kind.Def>

--- a/base/Kind/Defs/read.kind
+++ b/base/Kind/Defs/read.kind
@@ -1,4 +1,4 @@
-Kind.Defs.read(file: String, code: String, defs: Kind.Defs): Either(String, Kind.Defs)
+Kind.Defs.read(file: String, code: String, defs: Kind.Defs): Either<String, Kind.Defs>
   case Kind.Parser.file(file, code, defs, 0, code) as parsed {
     error:
       let err = parsed.err

--- a/base/Kind/Defs/report.kind
+++ b/base/Kind/Defs/report.kind
@@ -1,4 +1,4 @@
-Kind.Defs.report(defs: Kind.Defs, names: List(Kind.Name)): String
+Kind.Defs.report(defs: Kind.Defs, names: List<Kind.Name>): String
   let types = Kind.Defs.report.types(defs, names)
   let errors = Kind.Defs.report.errors(defs)
   let errors = case errors {
@@ -34,7 +34,7 @@ Kind.Defs.report.errors(defs: Kind.Defs): String
     } default errors
   errors
 
-Kind.Defs.report.types(defs: Kind.Defs, names: List(Kind.Name)): String
+Kind.Defs.report.types(defs: Kind.Defs, names: List<Kind.Name>): String
   let types = ""
   let types = for name in names:
     case Kind.Map.get!(name, defs) as got {

--- a/base/Kind/Error.kind
+++ b/base/Kind/Error.kind
@@ -1,17 +1,17 @@
 type Kind.Error {
   // Two types do not match
   type_mismatch(
-    origin: Maybe(Pair(Nat,Nat)),
-    expected: Either(String, Kind.Term),
-    detected: Either(String, Kind.Term),
+    origin: Maybe<Pair<Nat,Nat>>,
+    expected: Either<String, Kind.Term>,
+    detected: Either<String, Kind.Term>,
     context: Kind.Context,
   ),
   // Found a goal to be shown
   show_goal(
     name: Kind.Name,
-    dref: List(Bits),
+    dref: List<Bits>,
     verb: Bool,
-    goal: Maybe(Kind.Term),
+    goal: Maybe<Kind.Term>,
     context: Kind.Context,
   ),
   // Waits for another term's type checking
@@ -29,12 +29,12 @@ type Kind.Error {
   ),
   // Some reference isn't found
   undefined_reference(
-    origin: Maybe(Pair(Nat,Nat)),
+    origin: Maybe<Pair<Nat,Nat>>,
     name: Kind.Name,
   ),
   // A lambda without a type
   cant_infer(
-    origin: Maybe(Pair(Nat,Nat)),
+    origin: Maybe<Pair<Nat,Nat>>,
     term: Kind.Term,
     context: Kind.Context,
   ),

--- a/base/Kind/Error/origin.kind
+++ b/base/Kind/Error/origin.kind
@@ -1,4 +1,4 @@
-Kind.Error.origin(error: Kind.Error): Maybe(Pair(Nat,Nat))
+Kind.Error.origin(error: Kind.Error): Maybe<Pair<Nat,Nat>>
   case error {
     type_mismatch: error.origin,
     undefined_reference: error.origin,

--- a/base/Kind/Error/relevant.kind
+++ b/base/Kind/Error/relevant.kind
@@ -1,4 +1,4 @@
-Kind.Error.relevant(errors: List(Kind.Error), got: Bool): List(Kind.Error)
+Kind.Error.relevant(errors: List<Kind.Error>, got: Bool): List<Kind.Error>
   case errors {
     nil: [],
     cons:

--- a/base/Kind/MPath.kind
+++ b/base/Kind/MPath.kind
@@ -1,2 +1,2 @@
 Kind.MPath: Type
-  Maybe(Kind.Path)
+  Maybe<Kind.Path>

--- a/base/Kind/MPath/i.kind
+++ b/base/Kind/MPath/i.kind
@@ -1,2 +1,2 @@
-Kind.MPath.i(path: Maybe(Kind.Path)): Maybe(Kind.Path)
+Kind.MPath.i(path: Maybe<Kind.Path>): Maybe<Kind.Path>
   Maybe.mapped!(path)!(Kind.Path.i)

--- a/base/Kind/MPath/nil.kind
+++ b/base/Kind/MPath/nil.kind
@@ -1,2 +1,2 @@
-Kind.MPath.nil: Maybe(Kind.Path)
+Kind.MPath.nil: Maybe<Kind.Path>
   Maybe.some!(Kind.Path.nil)

--- a/base/Kind/MPath/o.kind
+++ b/base/Kind/MPath/o.kind
@@ -1,2 +1,2 @@
-Kind.MPath.o(path: Maybe(Kind.Path)): Maybe(Kind.Path)
+Kind.MPath.o(path: Maybe<Kind.Path>): Maybe<Kind.Path>
   Maybe.mapped!(path)!(Kind.Path.o)

--- a/base/Kind/MPath/to_bits.kind
+++ b/base/Kind/MPath/to_bits.kind
@@ -1,4 +1,4 @@
-Kind.MPath.to_bits(path: Maybe(Kind.Path)): Bits
+Kind.MPath.to_bits(path: Maybe<Kind.Path>): Bits
   case path {
     none: Bits.e,
     some: path.value(Bits.e),

--- a/base/Kind/Map/def.kind
+++ b/base/Kind/Map/def.kind
@@ -1,7 +1,7 @@
 Kind.Map.def(
   file: String,
   code: String,
-  orig: Pair(Nat,Nat),
+  orig: Pair<Nat,Nat>,
   name: Kind.Name,
   term: Kind.Term,
   type: Kind.Term,

--- a/base/Kind/Map/get.kind
+++ b/base/Kind/Map/get.kind
@@ -1,2 +1,2 @@
-Kind.Map.get<A: Type>(name: Kind.Name, map: BitsMap(A)): Maybe(A)
+Kind.Map.get<A: Type>(name: Kind.Name, map: BitsMap<A>): Maybe<A>
   BitsMap.get<A>(Kind.Name.to_bits(name), map)

--- a/base/Kind/Map/set.kind
+++ b/base/Kind/Map/set.kind
@@ -1,2 +1,2 @@
-Kind.Map.set<A: Type>(name: Kind.Name, val: A, map: BitsMap(A)): BitsMap(A)
+Kind.Map.set<A: Type>(name: Kind.Name, val: A, map: BitsMap<A>): BitsMap<A>
   BitsMap.set<A>(Kind.Name.to_bits(name), val, map)

--- a/base/Kind/Parser/binder.kind
+++ b/base/Kind/Parser/binder.kind
@@ -1,4 +1,4 @@
-Kind.Parser.binder(sep: String): Parser(List(Kind.Binder))
+Kind.Parser.binder(sep: String): Parser(List<Kind.Binder>)
   Parser {
     get lists = Parser.many1!(Parser.first_of!([
       Kind.Parser.binder.homo(sep, Bool.true),

--- a/base/Kind/Parser/binder/homo.kind
+++ b/base/Kind/Parser/binder/homo.kind
@@ -1,4 +1,4 @@
-Kind.Parser.binder.homo(sep: String, eras: Bool): Parser(List(Kind.Binder))
+Kind.Parser.binder.homo(sep: String, eras: Bool): Parser(List<Kind.Binder>)
   Parser {
     Kind.Parser.text(if eras then "<" else "(");
     get bind = Parser.until1!(

--- a/base/Kind/Parser/case/case.kind
+++ b/base/Kind/Parser/case/case.kind
@@ -1,4 +1,4 @@
-Kind.Parser.case.case: Parser(Pair(Kind.Name, Kind.Term))
+Kind.Parser.case.case: Parser(Pair<Kind.Name, Kind.Term>)
   Parser {
     get name = Kind.Parser.name1;
     Kind.Parser.text(":");

--- a/base/Kind/Parser/make_forall.kind
+++ b/base/Kind/Parser/make_forall.kind
@@ -1,4 +1,4 @@
-Kind.Parser.make_forall(binds: List(Kind.Binder), body: Kind.Term): Kind.Term
+Kind.Parser.make_forall(binds: List<Kind.Binder>, body: Kind.Term): Kind.Term
   case binds {
     nil: body,
     cons: case binds.head {

--- a/base/Kind/Parser/make_lambda.kind
+++ b/base/Kind/Parser/make_lambda.kind
@@ -1,4 +1,4 @@
-Kind.Parser.make_lambda(names: List(Kind.Name), body: Kind.Term): Kind.Term
+Kind.Parser.make_lambda(names: List<Kind.Name>, body: Kind.Term): Kind.Term
   case names {
     nil: body,
     cons: Kind.Term.lam(names.head, (x) Kind.Parser.make_lambda(names.tail, body)),

--- a/base/Kind/Parser/name_term.kind
+++ b/base/Kind/Parser/name_term.kind
@@ -1,4 +1,4 @@
-Kind.Parser.name_term(sep: String): Parser(Pair(Kind.Name, Kind.Term))
+Kind.Parser.name_term(sep: String): Parser(Pair<Kind.Name, Kind.Term>)
   Parser {
     get name = Kind.Parser.name;
     Kind.Parser.text(sep);

--- a/base/Kind/Parser/spaces.kind
+++ b/base/Kind/Parser/spaces.kind
@@ -1,4 +1,4 @@
-Kind.Parser.spaces: Parser(List(Unit))
+Kind.Parser.spaces: Parser(List<Unit>)
   Parser.many!(Parser.first_of!([
     Parser.text(" "),
     Parser.text("\t"),

--- a/base/Kind/Parser/stop.kind
+++ b/base/Kind/Parser/stop.kind
@@ -1,4 +1,4 @@
-Kind.Parser.stop(from: Nat): Parser(Pair(Nat,Nat))
+Kind.Parser.stop(from: Nat): Parser(Pair<Nat,Nat>)
   Parser {
     get upto = Parser.get_index;
     let orig = {from, upto};

--- a/base/Kind/Parser/string.kind
+++ b/base/Kind/Parser/string.kind
@@ -2,7 +2,7 @@ Kind.Parser.string.go(
   str: String,
   idx: Nat,
   code: String,
-): Parser.Reply(String)
+): Parser.Reply<String>
   case code {
     nil:
       Parser.Reply.error<String>(idx, code, "Non-terminating string.")

--- a/base/Kind/Parser/switch.kind
+++ b/base/Kind/Parser/switch.kind
@@ -1,4 +1,4 @@
-Kind.Parser.switch.case: Parser(Pair(Kind.Term, Kind.Term))
+Kind.Parser.switch.case: Parser(Pair<Kind.Term, Kind.Term>)
   Parser {
     get key = Kind.Parser.term;
     Kind.Parser.text(":");

--- a/base/Kind/Prim.kind
+++ b/base/Kind/Prim.kind
@@ -3,6 +3,6 @@ type Kind.Prim {
   nat,
   u16,
   string,
-  data(ctrs: List(Nat)),
+  data(ctrs: List<Nat>),
   //bits,
 }

--- a/base/Kind/SmartMotive/nams.kind
+++ b/base/Kind/SmartMotive/nams.kind
@@ -1,4 +1,4 @@
-Kind.SmartMotive.nams(name: Kind.Name, type: Kind.Term, defs: Kind.Defs): List(Kind.Name)
+Kind.SmartMotive.nams(name: Kind.Name, type: Kind.Term, defs: Kind.Defs): List<Kind.Name>
   case Kind.Term.reduce(type, defs) as type {
     all: Kind.SmartMotive.nams.cont(name, type.xtyp, [], defs),
     _: [],

--- a/base/Kind/SmartMotive/nams/cont.kind
+++ b/base/Kind/SmartMotive/nams/cont.kind
@@ -1,4 +1,4 @@
-Kind.SmartMotive.nams.cont(name: Kind.Name, term: Kind.Term, binds: List(Kind.Name), defs: Kind.Defs): List(Kind.Name)
+Kind.SmartMotive.nams.cont(name: Kind.Name, term: Kind.Term, binds: List<Kind.Name>, defs: Kind.Defs): List<Kind.Name>
   case Kind.Term.reduce(term, defs) as term {
     all: Kind.SmartMotive.nams.cont(
       name,

--- a/base/Kind/SmartMotive/vals.kind
+++ b/base/Kind/SmartMotive/vals.kind
@@ -1,4 +1,4 @@
-Kind.SmartMotive.vals(expr: Kind.Term, type: Kind.Term, defs: Kind.Defs): List(Kind.Term)
+Kind.SmartMotive.vals(expr: Kind.Term, type: Kind.Term, defs: Kind.Defs): List<Kind.Term>
   case Kind.Term.reduce(type, defs) as type {
     all: Kind.SmartMotive.vals(expr, type.body(Kind.Term.typ,Kind.Term.typ), defs),
     _: Kind.SmartMotive.vals.cont(expr, type, [], defs),

--- a/base/Kind/SmartMotive/vals/cont.kind
+++ b/base/Kind/SmartMotive/vals/cont.kind
@@ -1,4 +1,4 @@
-Kind.SmartMotive.vals.cont(expr: Kind.Term, term: Kind.Term, args: List(Kind.Term), defs: Kind.Defs): List(Kind.Term)
+Kind.SmartMotive.vals.cont(expr: Kind.Term, term: Kind.Term, args: List<Kind.Term>, defs: Kind.Defs): List<Kind.Term>
   case Kind.Term.reduce(term, defs) as term {
     app: Kind.SmartMotive.vals.cont(expr, term.func, List.cons!(term.argm, args), defs),
     _: List.cons!(expr, List.tail!(List.reverse!(args))),

--- a/base/Kind/Status.kind
+++ b/base/Kind/Status.kind
@@ -2,5 +2,5 @@ type Kind.Status {
   init,
   wait,
   done,
-  fail(errors: List(Kind.Error)),
+  fail(errors: List<Kind.Error>),
 }

--- a/base/Kind/Synth/file.kind
+++ b/base/Kind/Synth/file.kind
@@ -1,4 +1,4 @@
-Kind.Synth.file(file: String, defs: Kind.Defs): IO(Either(String, Pair(List(Kind.Name), Kind.Defs)))
+Kind.Synth.file(file: String, defs: Kind.Defs): IO<Either<String, Pair<List<Kind.Name>, Kind.Defs>>>
   IO {
     get code = IO.get_file(file);
     let read = Kind.Defs.read(file, code, defs);

--- a/base/Kind/Synth/files.kind
+++ b/base/Kind/Synth/files.kind
@@ -1,4 +1,4 @@
-Kind.Synth.files.go(files: List<String>, defs: Kind.Defs): IO(Pair(List(Kind.Name), Kind.Defs))
+Kind.Synth.files.go(files: List<String>, defs: Kind.Defs): IO<Pair<List<Kind.Name>, Kind.Defs>>
   case files {
     nil: IO {
       return {List.nil!, defs}
@@ -23,7 +23,7 @@ Kind.Synth.remove_duplicate_names(names: List<String>): List<String>
   let map = List.fold!(names)!(Kind.Map.new!, (name) Kind.Map.set!(name, unit))
   List.mapped!(BitsMap.keys!(map))!(Kind.Name.from_bits)
 
-Kind.Synth.files(files: List<String>, defs: Kind.Defs): IO(Pair(List(Kind.Name), Kind.Defs))
+Kind.Synth.files(files: List<String>, defs: Kind.Defs): IO<Pair<List<Kind.Name>, Kind.Defs>>
   IO {
     var got = Kind.Synth.files.go(files, defs)
     let nams = Kind.Synth.remove_duplicate_names(Pair.fst!!(got))

--- a/base/Kind/Synth/files_of.kind
+++ b/base/Kind/Synth/files_of.kind
@@ -1,2 +1,2 @@
-Kind.Synth.files_of(name: Kind.Name): List(String)
+Kind.Synth.files_of(name: Kind.Name): List<String>
   List.reverse!(Kind.Synth.files_of.make(String.split(name, "."), ""))

--- a/base/Kind/Synth/files_of/make.kind
+++ b/base/Kind/Synth/files_of/make.kind
@@ -1,4 +1,4 @@
-Kind.Synth.files_of.make(names: List(String), last: String): List(String)
+Kind.Synth.files_of.make(names: List<String>, last: String): List<String>
   case names {
     nil:
       []

--- a/base/Kind/Synth/fix.kind
+++ b/base/Kind/Synth/fix.kind
@@ -1,16 +1,16 @@
 Kind.Synth.fix(
   file: String,
   code: String,
-  orig: Pair(Nat,Nat),
+  orig: Pair<Nat,Nat>,
   name: Kind.Name,
   term: Kind.Term,
   type: Kind.Term,
   isct: Bool,
   arit: Nat,
   defs: Kind.Defs,
-  errs: List(Kind.Error),
+  errs: List<Kind.Error>,
   fixd: Bool,
-): IO(Maybe(Kind.Defs))
+): IO<Maybe<Kind.Defs>>
   case errs {
     nil:
       if fixd then IO {

--- a/base/Kind/Synth/load.kind
+++ b/base/Kind/Synth/load.kind
@@ -1,2 +1,2 @@
-Kind.Synth.load(name: Kind.Name, defs: Kind.Defs): IO(Maybe(Kind.Defs))
+Kind.Synth.load(name: Kind.Name, defs: Kind.Defs): IO<Maybe<Kind.Defs>>
   Kind.Synth.load.go(name, Kind.Synth.files_of(name), defs)

--- a/base/Kind/Synth/load/go.kind
+++ b/base/Kind/Synth/load/go.kind
@@ -1,4 +1,4 @@
-Kind.Synth.load.go(name: String, files: List(String), defs: Kind.Defs): IO(Maybe(Kind.Defs))
+Kind.Synth.load.go(name: String, files: List<String>, defs: Kind.Defs): IO<Maybe<Kind.Defs>>
   case files {
     nil: IO {
       return none

--- a/base/Kind/Synth/many.kind
+++ b/base/Kind/Synth/many.kind
@@ -1,4 +1,4 @@
-Kind.Synth.many(names: List(String), defs: Kind.Defs): IO(Kind.Defs)
+Kind.Synth.many(names: List<String>, defs: Kind.Defs): IO<Kind.Defs>
   case names {
     nil: IO {
       return defs;

--- a/base/Kind/Synth/one.kind
+++ b/base/Kind/Synth/one.kind
@@ -1,4 +1,4 @@
-Kind.Synth.one(name: Kind.Name, defs: Kind.Defs): IO(Maybe(Kind.Defs))
+Kind.Synth.one(name: Kind.Name, defs: Kind.Defs): IO<Maybe<Kind.Defs>>
   //log("synth ", name)
   case Kind.Map.get!(name, defs) as got {
     none: IO {

--- a/base/Kind/Term.kind
+++ b/base/Kind/Term.kind
@@ -49,7 +49,7 @@ type Kind.Term {
   // A hole to show the goal
   gol(
     name: Kind.Name, // the goal's name
-    dref: List(Bits), // a list of labels to expand when displaying it
+    dref: List<Bits>, // a list of labels to expand when displaying it
     verb: Bool, // show labels of expandable terms?
   ),
   // A hole to be auto-filled
@@ -73,13 +73,13 @@ type Kind.Term {
     path: Bits,
     expr: Kind.Term,
     name: Kind.Name,
-    with: List(Kind.Def),
-    cses: BitsMap(Kind.Term),
-    moti: Maybe(Kind.Term),
+    with: List<Kind.Def>,
+    cses: BitsMap<Kind.Term>,
+    moti: Maybe<Kind.Term>,
   ),
   // An origin
   ori(
-    orig: Pair(Nat,Nat),
+    orig: Pair<Nat,Nat>,
     expr: Kind.Term,
   )
 }

--- a/base/Kind/Term/check.kind
+++ b/base/Kind/Term/check.kind
@@ -1,11 +1,11 @@
 Kind.Term.check(
   term: Kind.Term,
-  type: Maybe(Kind.Term),
+  type: Maybe<Kind.Term>,
   defs: Kind.Defs,
   ctx: Kind.Context,
   path: Kind.MPath,
-  orig: Maybe(Pair(Nat,Nat)),
-): Kind.Check(Kind.Term)
+  orig: Maybe<Pair<Nat,Nat>>,
+): Kind.Check<Kind.Term>
   do Kind.Check {
     get infr = case term {
       ref: case Kind.Map.get!(term.name, defs) as got {

--- a/base/Kind/Term/desugar_cse.kind
+++ b/base/Kind/Term/desugar_cse.kind
@@ -1,13 +1,13 @@
 Kind.Term.desugar_cse(
   expr: Kind.Term,
   name: Kind.Name,
-  wyth: List(Kind.Def),
-  cses: BitsMap(Kind.Term),
+  wyth: List<Kind.Def>,
+  cses: BitsMap<Kind.Term>,
   moti: Kind.Term,
   type: Kind.Term,
   defs: Kind.Defs,
   ctxt: Kind.Context,
-): Maybe(Kind.Term)
+): Maybe<Kind.Term>
   case Kind.Term.reduce(type, defs) as type {
     all:
       let moti = Kind.Term.desugar_cse.motive(wyth, moti);

--- a/base/Kind/Term/desugar_cse/argument.kind
+++ b/base/Kind/Term/desugar_cse/argument.kind
@@ -1,6 +1,6 @@
 Kind.Term.desugar_cse.argument(
   name: Kind.Name,
-  wyth: List(Kind.Def),
+  wyth: List<Kind.Def>,
   type: Kind.Term,
   body: Kind.Term,
   defs: Kind.Defs,

--- a/base/Kind/Term/desugar_cse/cases.kind
+++ b/base/Kind/Term/desugar_cse/cases.kind
@@ -1,8 +1,8 @@
 Kind.Term.desugar_cse.cases(
   expr: Kind.Term,
   name: Kind.Name,
-  wyth: List(Kind.Def),
-  cses: BitsMap(Kind.Term),
+  wyth: List<Kind.Def>,
+  cses: BitsMap<Kind.Term>,
   type: Kind.Term,
   defs: Kind.Defs,
   ctxt: Kind.Context,

--- a/base/Kind/Term/desugar_cse/motive.kind
+++ b/base/Kind/Term/desugar_cse/motive.kind
@@ -1,5 +1,5 @@
 Kind.Term.desugar_cse.motive(
-  wyth: List(Kind.Def),
+  wyth: List<Kind.Def>,
   moti: Kind.Term,
 ): Kind.Term
   case wyth {

--- a/base/Kind/Term/equal.kind
+++ b/base/Kind/Term/equal.kind
@@ -1,4 +1,4 @@
-Kind.Term.equal(a: Kind.Term, b: Kind.Term, defs: Kind.Defs, lv: Nat, seen: BitsSet): Kind.Check(Bool)
+Kind.Term.equal(a: Kind.Term, b: Kind.Term, defs: Kind.Defs, lv: Nat, seen: BitsSet): Kind.Check<Bool>
   let ah = Kind.Term.serialize(Kind.Term.reduce(a,Kind.Map.new!), lv, lv, Bits.o, Bits.e);
   let bh = Kind.Term.serialize(Kind.Term.reduce(b,Kind.Map.new!), lv, lv, Bits.i, Bits.e);
   if Bits.eql(ah, bh) then do Kind.Check {

--- a/base/Kind/Term/equal/extra_holes.kind
+++ b/base/Kind/Term/equal/extra_holes.kind
@@ -8,7 +8,7 @@
 Kind.Term.equal.extra_holes.funari(
   term: Kind.Term,
   arity: Nat,
-): Maybe(Pair(String, Nat))
+): Maybe<Pair<String, Nat>>
   case term {
     app: Kind.Term.equal.extra_holes.funari(term.func, Nat.succ(arity))
     ori: Kind.Term.equal.extra_holes.funari(term.expr, arity)
@@ -21,7 +21,7 @@ Kind.Term.equal.extra_holes.funari(
 Kind.Term.equal.extra_holes.filler(
   a: Kind.Term,
   b: Kind.Term,
-): Kind.Check(Unit)
+): Kind.Check<Unit>
   case a {
     app: case b {
       app: do Kind.Check {
@@ -42,7 +42,7 @@ Kind.Term.equal.extra_holes.filler(
   }
 
 // Checks eligibility and calls the filler
-Kind.Term.equal.extra_holes(a: Kind.Term, b: Kind.Term): Kind.Check(Unit)
+Kind.Term.equal.extra_holes(a: Kind.Term, b: Kind.Term): Kind.Check<Unit>
   case Kind.Term.equal.extra_holes.funari(a,0) as a_funari {
     none: do Kind.Check { return Unit.new }
     some: case Kind.Term.equal.extra_holes.funari(b,0) as b_funari {

--- a/base/Kind/Term/equal/hole.kind
+++ b/base/Kind/Term/equal/hole.kind
@@ -1,4 +1,4 @@
-Kind.Term.equal.hole(path: Bits, term: Kind.Term): Kind.Check(Bool)
+Kind.Term.equal.hole(path: Bits, term: Kind.Term): Kind.Check<Bool>
   case term {
     hol: Kind.Check.result!(some(true), []),
     _: if Kind.Term.has_holes(term)

--- a/base/Kind/Term/expand.kind
+++ b/base/Kind/Term/expand.kind
@@ -1,4 +1,4 @@
-Kind.Term.expand(dref: List(Bits), term: Kind.Term, defs: Kind.Defs): Kind.Term
+Kind.Term.expand(dref: List<Bits>, term: Kind.Term, defs: Kind.Defs): Kind.Term
   let term = Kind.Term.normalize(term, Kind.Map.new!);
   let term = for path in dref:
     let term = Kind.Term.expand_at(path, term, defs);

--- a/base/Kind/Term/read.kind
+++ b/base/Kind/Term/read.kind
@@ -1,4 +1,4 @@
-Kind.Term.read(code: String): Maybe(Kind.Term)
+Kind.Term.read(code: String): Maybe<Kind.Term>
   case Kind.Parser.term(0,code) as parsed {
     error: Maybe.none!,
     value: Maybe.some!(parsed.val),

--- a/base/Kind/Term/show/app.kind
+++ b/base/Kind/Term/show/app.kind
@@ -1,4 +1,4 @@
-Kind.Term.show.app(term: Kind.Term, path: Maybe(Bits -> Bits), args: List(String)): String
+Kind.Term.show.app(term: Kind.Term, path: Maybe<Bits -> Bits>, args: List<String>): String
   case term {
     app: Kind.Term.show.app(term.func, Kind.MPath.o(path), Kind.Term.show.go(term.argm, Kind.MPath.i(path)) & args),
     ori: Kind.Term.show.app(term.expr, path, args),

--- a/base/Kind/Term/show/app/done.kind
+++ b/base/Kind/Term/show/app/done.kind
@@ -1,4 +1,4 @@
-Kind.Term.show.app.done(term: Kind.Term, path: Maybe(Bits -> Bits), args: List(String)): String
+Kind.Term.show.app.done(term: Kind.Term, path: Maybe<Bits -> Bits>, args: List<String>): String
   let arity = List.length!(args);
   if Bool.and(Kind.Term.show.is_ref(term,"Equal"), Nat.eql(arity,3)) then
     let func = Kind.Term.show.go(term, path);

--- a/base/Kind/Term/show/as_nat.kind
+++ b/base/Kind/Term/show/as_nat.kind
@@ -1,2 +1,2 @@
-Kind.Term.show.as_nat(term: Kind.Term): Maybe(String)
+Kind.Term.show.as_nat(term: Kind.Term): Maybe<String>
   Maybe.mapped!(Kind.Term.show.as_nat.go(term))!(Nat.show)

--- a/base/Kind/Term/show/as_nat/go.kind
+++ b/base/Kind/Term/show/as_nat/go.kind
@@ -1,4 +1,4 @@
-Kind.Term.show.as_nat.go(term: Kind.Term): Maybe(Nat)
+Kind.Term.show.as_nat.go(term: Kind.Term): Maybe<Nat>
   case term {
     app: case term.func {
       ref: 

--- a/base/Kind/Term/show/go.kind
+++ b/base/Kind/Term/show/go.kind
@@ -1,4 +1,4 @@
-Kind.Term.show.go(term: Kind.Term, path: Maybe(Bits -> Bits)): String
+Kind.Term.show.go(term: Kind.Term, path: Maybe<Bits -> Bits>): String
   case Kind.Term.show.as_nat(term) as as_nat {
     some: as_nat.value,
     none: case term {

--- a/base/Kind/api/export.kind
+++ b/base/Kind/api/export.kind
@@ -1,4 +1,4 @@
-Kind.api.export: IO(Unit)
+Kind.api.export: IO<Unit>
   IO {
     let e = Kind.api.io.term_to_core
     let e = Kind.api.io.check_file

--- a/base/Kind/api/io/check_file.kind
+++ b/base/Kind/api/io/check_file.kind
@@ -1,4 +1,4 @@
-Kind.api.io.check_file(file: String): IO(Unit)
+Kind.api.io.check_file(file: String): IO<Unit>
   IO {
     get loaded = Kind.Synth.file(file, Kind.Map.new!)
     case loaded {

--- a/base/Kind/api/io/check_files.kind
+++ b/base/Kind/api/io/check_files.kind
@@ -1,4 +1,4 @@
-Kind.api.io.check_files(files: List<String>): IO(Unit)
+Kind.api.io.check_files(files: List<String>): IO<Unit>
   IO {
     get loaded = Kind.Synth.files(files, Kind.Map.new!)
     let nams = Pair.fst!!(loaded)

--- a/base/Kind/api/io/check_term.kind
+++ b/base/Kind/api/io/check_term.kind
@@ -1,5 +1,5 @@
 // TODO: remove duplicate code on Kind/api/io/normalize_term.kind
-Kind.api.io.check_term(name: String): IO(Unit)
+Kind.api.io.check_term(name: String): IO<Unit>
   IO {
     get new_defs = Kind.Synth.one(name, Kind.Map.new!)
     case new_defs {

--- a/base/Kind/api/io/show_term.kind
+++ b/base/Kind/api/io/show_term.kind
@@ -1,5 +1,5 @@
 // TODO: remove duplicate code on Kind/api/io/check_term.kind
-Kind.api.io.show_term(name: String): IO(Unit)
+Kind.api.io.show_term(name: String): IO<Unit>
   IO {
     get new_defs = Kind.Synth.one(name, Kind.Map.new!)
     IO.print(case new_defs {

--- a/base/Kind/api/io/show_term_normal.kind
+++ b/base/Kind/api/io/show_term_normal.kind
@@ -1,5 +1,5 @@
 // TODO: remove duplicate code on Kind/api/io/check_term.kind
-Kind.api.io.show_term_normal(name: String): IO(Unit)
+Kind.api.io.show_term_normal(name: String): IO<Unit>
   IO {
     get new_defs = Kind.Synth.one(name, Kind.Map.new!)
     IO.print(case new_defs {

--- a/base/Kind/api/io/term_to_core.kind
+++ b/base/Kind/api/io/term_to_core.kind
@@ -1,4 +1,4 @@
-Kind.api.io.term_to_core(name: String): IO(String)
+Kind.api.io.term_to_core(name: String): IO<String>
   IO {
     get new_defs = Kind.Synth.one(name, Kind.Map.new!);
     let defs = case new_defs {

--- a/base/List.kind
+++ b/base/List.kind
@@ -1,4 +1,4 @@
 type List <A: Type> {
   nil,
-  cons(head: A, tail: List(A)),
+  cons(head: A, tail: List<A>),
 }

--- a/base/List/Builder.kind
+++ b/base/List/Builder.kind
@@ -1,2 +1,2 @@
 List.Builder(A: Type): Type
-  List(A) -> List(A)
+  List<A> -> List<A>

--- a/base/List/all.kind
+++ b/base/List/all.kind
@@ -5,7 +5,7 @@
 // - List.all!(Nat.is_even, [2, 4, 6, 8]) == true
 // - ...
 // - ...
-List.all<A: Type>(cond: A -> Bool, list: List(A)): Bool
+List.all<A: Type>(cond: A -> Bool, list: List<A>): Bool
   case list{
     nil : Bool.true
     cons: case cond(list.head){

--- a/base/List/and.kind
+++ b/base/List/and.kind
@@ -1,2 +1,2 @@
-List.and(list: List(Bool)): Bool
+List.and(list: List<Bool>): Bool
   List.all!((x) x, list)

--- a/base/List/any.kind
+++ b/base/List/any.kind
@@ -1,4 +1,4 @@
-List.any<A: Type>(cond: A -> Bool, list: List(A)): Bool
+List.any<A: Type>(cond: A -> Bool, list: List<A>): Bool
   case list{
     nil : Bool.false
     cons: case cond(list.head){

--- a/base/List/append.kind
+++ b/base/List/append.kind
@@ -1,4 +1,4 @@
-List.append<A: Type>(as: List(A), a: A): List(A)
+List.append<A: Type>(as: List<A>, a: A): List<A>
   case as{
     nil : List.pure!(a)
     cons: List.cons!(as.head,List.append!(as.tail, a))

--- a/base/List/at.kind
+++ b/base/List/at.kind
@@ -1,4 +1,4 @@
-List.at<A: Type>(index: Nat, list: List(A)): Maybe(A)
+List.at<A: Type>(index: Nat, list: List<A>): Maybe<A>
   case list {
     nil: Maybe.none!,
     cons: case index {

--- a/base/List/at_last.kind
+++ b/base/List/at_last.kind
@@ -1,2 +1,2 @@
-List.at_last<A: Type>(index: Nat, list: List(A)): Maybe(A)
+List.at_last<A: Type>(index: Nat, list: List<A>): Maybe<A>
   List.at<A>(index, List.reverse!(list))

--- a/base/List/bind.kind
+++ b/base/List/bind.kind
@@ -1,2 +1,2 @@
-List.bind<A: Type,B: Type>(xs: List(A), f: A -> List(B)): List(B)
+List.bind<A: Type,B: Type>(xs: List<A>, f: A -> List<B>): List<B>
   List.flatten!(List.map!!(f, xs))

--- a/base/List/chunk.kind
+++ b/base/List/chunk.kind
@@ -1,4 +1,4 @@
-List.chunk<A: Type>(n: Nat, xs: List(A)): Maybe(List(A))
+List.chunk<A: Type>(n: Nat, xs: List<A>): Maybe<List<A>>
   case n {
     zero: Maybe.some!(List.nil!),
     succ: case xs {

--- a/base/List/chunks_of.kind
+++ b/base/List/chunks_of.kind
@@ -1,2 +1,2 @@
-List.chunks_of<A: Type>(len: Nat, xs: List(A)): List(List(A))
+List.chunks_of<A: Type>(len: Nat, xs: List<A>): List<List<A>>
   List.chunks_of.go!(len, xs, len, List.nil!)

--- a/base/List/chunks_of/go.kind
+++ b/base/List/chunks_of/go.kind
@@ -1,9 +1,9 @@
 List.chunks_of.go<A: Type>(
   len   : Nat,     // length of each chunk
-  list  : List(A), // list to be split
+  list  : List<A>, // list to be split
   need  : Nat,     // number of vals to complete chunk
-  chunk : List(A)  // current chunk
-) : List(List(A))
+  chunk : List<A>  // current chunk
+) : List<List<A>>
   case list {
     nil : List.cons!(List.reverse!(chunk), List.nil!),
     cons: case need {

--- a/base/List/commute_cons_map.kind
+++ b/base/List/commute_cons_map.kind
@@ -1,8 +1,8 @@
-List.commute_cons_map<A: Type, B: Type>(a :A, ls: List(A), f: A -> B)
-  : Equal(List(B),
+List.commute_cons_map<A: Type, B: Type>(a :A, ls: List<A>, f: A -> B)
+  : Equal<List<B>,
           List.cons<B>(f(a), List.map<A, B>(f, ls)),
-          List.map<A, B>(f, List.cons<A>(a, ls)))
+          List.map<A, B>(f, List.cons<A>(a, ls))>
   case ls {
     nil : Equal.refl!!
     cons: Equal.refl!!
-  } : Equal(_, List.cons!(f(a), List.map!!(f, ls)), List.map!!(f, List.cons!(a, ls)))
+  } : Equal<_, List.cons!(f(a), List.map!!(f, ls)), List.map!!(f, List.cons!(a, ls))>

--- a/base/List/concat.kind
+++ b/base/List/concat.kind
@@ -1,4 +1,4 @@
-List.concat<A: Type>(as: List(A), bs: List(A)): List(A)
+List.concat<A: Type>(as: List<A>, bs: List<A>): List<A>
   case as {
     nil: bs,
     cons: List.cons!(as.head, List.concat!(as.tail,bs))

--- a/base/List/delete_at.kind
+++ b/base/List/delete_at.kind
@@ -1,4 +1,4 @@
-List.delete_at<A: Type>(idx: Nat, list: List(A)): List(A)
+List.delete_at<A: Type>(idx: Nat, list: List<A>): List<A>
   case idx{
     zero: List.tail<A>(list)
     succ: case list{

--- a/base/List/delete_by.kind
+++ b/base/List/delete_by.kind
@@ -1,4 +1,4 @@
-List.delete_by<A: Type>(p: A -> A -> Bool, a: A, as: List(A)): List(A)
+List.delete_by<A: Type>(p: A -> A -> Bool, a: A, as: List<A>): List<A>
   case as {
     nil : List.nil!,
     cons: case p(a, as.head) {

--- a/base/List/drop.kind
+++ b/base/List/drop.kind
@@ -1,4 +1,4 @@
-List.drop<A: Type>(n: Nat, xs: List(A)): List(A)
+List.drop<A: Type>(n: Nat, xs: List<A>): List<A>
   case n{
     zero: xs
     succ: case xs{

--- a/base/List/drop_while.kind
+++ b/base/List/drop_while.kind
@@ -1,4 +1,4 @@
-List.drop_while<A: Type>(f: A -> Bool, xs: List(A)): List(A)
+List.drop_while<A: Type>(f: A -> Bool, xs: List<A>): List<A>
   case xs{
     nil : List.nil!
     cons: case f(xs.head){

--- a/base/List/elem.kind
+++ b/base/List/elem.kind
@@ -1,4 +1,4 @@
-List.elem<A: Type>(p: A -> A -> Bool, a: A, as: List(A)): Bool 
+List.elem<A: Type>(p: A -> A -> Bool, a: A, as: List<A>): Bool 
   case as {
     nil : Bool.false,
     cons: case p(a, as.head) {

--- a/base/List/eql.kind
+++ b/base/List/eql.kind
@@ -1,4 +1,4 @@
-List.eql<A: Type>(eql: A -> A -> Bool, a: List(A), b: List(A)): Bool
+List.eql<A: Type>(eql: A -> A -> Bool, a: List<A>, b: List<A>): Bool
   case a {
     nil: case b {
       nil: Bool.true,

--- a/base/List/filter.kind
+++ b/base/List/filter.kind
@@ -1,4 +1,4 @@
-List.filter<A: Type>(f: A -> Bool, xs: List(A)): List(A)
+List.filter<A: Type>(f: A -> Bool, xs: List<A>): List<A>
   case xs{
     nil : List.nil!
     cons: case f(xs.head){

--- a/base/List/find.kind
+++ b/base/List/find.kind
@@ -1,4 +1,4 @@
-List.find<A: Type>(cond: A -> Bool, xs: List(A)): Maybe(A)
+List.find<A: Type>(cond: A -> Bool, xs: List<A>): Maybe<A>
   case xs{
   nil : Maybe.none!
   cons: case cond(xs.head){

--- a/base/List/find_last.kind
+++ b/base/List/find_last.kind
@@ -1,2 +1,2 @@
-List.find_last<A: Type>(xs: List(A), f: A -> Nat -> Bool): Maybe(Pair(A)(Nat))
+List.find_last<A: Type>(xs: List<A>, f: A -> Nat -> Bool): Maybe<Pair<A,Nat>>
   List.find_last.go<A>(xs,f,Nat.zero,Maybe.none!)

--- a/base/List/find_last/go.kind
+++ b/base/List/find_last/go.kind
@@ -1,9 +1,9 @@
 List.find_last.go<A: Type>(
-  xs: List(A),
+  xs: List<A>,
   f: A -> Nat -> Bool,
   n: Nat,
-  res: Maybe(Pair(A,Nat))
-): Maybe(Pair(A,Nat))
+  res: Maybe<Pair<A,Nat>>
+): Maybe<Pair<A,Nat>>
   case xs {
     nil : res,
     cons:

--- a/base/List/flatten.kind
+++ b/base/List/flatten.kind
@@ -1,4 +1,4 @@
-List.flatten<A: Type>(xs: List(List(A))): List(A)
+List.flatten<A: Type>(xs: List<List<A>>): List<A>
   case xs {
     nil: List.nil!,
     cons: List.concat!(xs.head, List.flatten!(xs.tail))

--- a/base/List/fold.kind
+++ b/base/List/fold.kind
@@ -1,4 +1,4 @@
-List.fold<A: Type>(list: List(A)): <P: Type> -> P -> (A -> P -> P) -> P
+List.fold<A: Type>(list: List<A>): <P: Type> -> P -> (A -> P -> P) -> P
   <P> (nil, cons)
   case list {
     nil : nil,

--- a/base/List/fold_zip.kind
+++ b/base/List/fold_zip.kind
@@ -1,4 +1,4 @@
-List.fold_zip<A: Type, B: Type>(as: List(A), bs: List(B))<C: Type>(fn: A -> B -> C, nil: C, cons: C -> C -> C): C
+List.fold_zip<A: Type, B: Type>(as: List<A>, bs: List<B>)<C: Type>(fn: A -> B -> C, nil: C, cons: C -> C -> C): C
   case as {
     nil : nil,
     cons: case bs {

--- a/base/List/foldr.kind
+++ b/base/List/foldr.kind
@@ -1,2 +1,2 @@
-List.foldr<A: Type,B: Type>(b: B, f: A -> B -> B, xs: List(A)): B
+List.foldr<A: Type,B: Type>(b: B, f: A -> B -> B, xs: List<A>): B
   List.fold<A>(xs)<B>(b,f)

--- a/base/List/for.kind
+++ b/base/List/for.kind
@@ -1,4 +1,4 @@
-List.for<A: Type>(xs: List(A))<B: Type>(b: B, f: A -> B -> B): B
+List.for<A: Type>(xs: List<A>)<B: Type>(b: B, f: A -> B -> B): B
   case xs {
     nil : b,
     cons: List.for<A>(xs.tail)<B>(f(xs.head,b),f)

--- a/base/List/get.kind
+++ b/base/List/get.kind
@@ -1,4 +1,4 @@
-List.get<A: Type>(index: Nat, list: List<A>): Maybe(A)
+List.get<A: Type>(index: Nat, list: List<A>): Maybe<A>
   case list {
     nil: none
     cons: case index {

--- a/base/List/head.kind
+++ b/base/List/head.kind
@@ -1,4 +1,4 @@
-List.head<A: Type>(xs: List(A)): Maybe(A)
+List.head<A: Type>(xs: List<A>): Maybe<A>
   case xs {
     nil : Maybe.none!,
     cons: Maybe.some!(xs.head)

--- a/base/List/head_with_default.kind
+++ b/base/List/head_with_default.kind
@@ -1,4 +1,4 @@
-List.head_with_default<A: Type>(default: A, xs: List(A)): A
+List.head_with_default<A: Type>(default: A, xs: List<A>): A
   case xs {
     nil : default,
     cons: xs.head

--- a/base/List/ifind.kind
+++ b/base/List/ifind.kind
@@ -1,2 +1,2 @@
-List.ifind<A: Type>(xs: List(A), f: A -> Nat -> Bool): Maybe(Pair(A,Nat))
+List.ifind<A: Type>(xs: List<A>, f: A -> Nat -> Bool): Maybe<Pair<A,Nat>>
   List.ifind.go<A>(xs,f,Nat.zero)

--- a/base/List/ifind/go.kind
+++ b/base/List/ifind/go.kind
@@ -1,4 +1,4 @@
-List.ifind.go<A: Type>(xs: List(A), f: A -> Nat -> Bool, i: Nat): Maybe(Pair(A,Nat))
+List.ifind.go<A: Type>(xs: List<A>, f: A -> Nat -> Bool, i: Nat): Maybe<Pair<A,Nat>>
   case xs {
     nil : Maybe.none!,
     cons: case f(xs.head,i) {

--- a/base/List/imap.kind
+++ b/base/List/imap.kind
@@ -1,4 +1,4 @@
-List.imap<A: Type,B: Type>(f: Nat -> A -> B, xs: List(A)): List(B)
+List.imap<A: Type,B: Type>(f: Nat -> A -> B, xs: List<A>): List<B>
   case xs {
     nil : List.nil!,
     cons: List.cons!(f(0,xs.head),List.imap!!((n) f(Nat.succ(n)),xs.tail))

--- a/base/List/indices.kind
+++ b/base/List/indices.kind
@@ -1,2 +1,2 @@
-List.indices<A: Type>(xs: List(A)): List(Pair(Nat,A))
-  List.imap<A,Pair(Nat,A)>((i,x) {i,x}, xs)
+List.indices<A: Type>(xs: List<A>): List<Pair<Nat,A>>
+  List.imap<A,Pair<Nat,A>>((i,x) {i,x}, xs)

--- a/base/List/indices/u32.kind
+++ b/base/List/indices/u32.kind
@@ -1,2 +1,2 @@
-List.indices.u32<A: Type>(xs: List(A)): List(Pair(U32,A))
-  List.imap<A,Pair(U32,A)>((i,x) {Nat.to_u32(i),x}, xs)
+List.indices.u32<A: Type>(xs: List<A>): List<Pair<U32,A>>
+  List.imap<A,Pair<U32,A>>((i,x) {Nat.to_u32(i),x}, xs)

--- a/base/List/init.kind
+++ b/base/List/init.kind
@@ -1,4 +1,4 @@
-List.init<A: Type>(list: List(A)): List(A)
+List.init<A: Type>(list: List<A>): List<A>
   case list {
     cons: case list.tail {
       cons: List.cons!(list.head, List.init<A>(list.tail)),

--- a/base/List/insert_sort_nat.kind
+++ b/base/List/insert_sort_nat.kind
@@ -1,2 +1,2 @@
-List.insert_sort_nat(ns: List(Nat)): List(Nat)
+List.insert_sort_nat(ns: List<Nat>): List<Nat>
   List.foldr!!(List.nil!, List.insert_sort_nat.aux, ns)

--- a/base/List/insert_sort_nat/aux.kind
+++ b/base/List/insert_sort_nat/aux.kind
@@ -1,3 +1,3 @@
-List.insert_sort_nat.aux(n: Nat, ns: List(Nat)): List(Nat)
+List.insert_sort_nat.aux(n: Nat, ns: List<Nat>): List<Nat>
   open List.span!(Nat.lte(n), ns) as spanned
   List.concat!(spanned.fst, List.cons!(n, spanned.snd))

--- a/base/List/intercalate.kind
+++ b/base/List/intercalate.kind
@@ -1,2 +1,2 @@
-List.intercalate<A: Type>(sep: List(A), xs: List(List(A))): List(A)
-  List.flatten<A>(List.intersperse<List(A)>(sep,xs))
+List.intercalate<A: Type>(sep: List<A>, xs: List<List<A>>): List<A>
+  List.flatten<A>(List.intersperse<List<A>>(sep,xs))

--- a/base/List/intersperse.kind
+++ b/base/List/intersperse.kind
@@ -1,4 +1,4 @@
-List.intersperse<A: Type>(sep: A, xs: List(A)): List(A)
+List.intersperse<A: Type>(sep: A, xs: List<A>): List<A>
   case xs{
     nil : List.nil!
     cons: case xs.tail{

--- a/base/List/is_empty.kind
+++ b/base/List/is_empty.kind
@@ -1,4 +1,4 @@
-List.is_empty<A: Type>(list: List(A)): Bool
+List.is_empty<A: Type>(list: List<A>): Bool
   case list {
     nil: Bool.true,
     cons: Bool.false,

--- a/base/List/length.kind
+++ b/base/List/length.kind
@@ -1,4 +1,4 @@
-List.length<A: Type>(xs: List(A)): Nat
+List.length<A: Type>(xs: List<A>): Nat
   case xs {
     nil: 0,
     cons: Nat.succ(List.length<A>(xs.tail)),

--- a/base/List/map.kind
+++ b/base/List/map.kind
@@ -1,4 +1,4 @@
-List.map<A: Type, B: Type>(f: A -> B, as: List(A)): List(B)
+List.map<A: Type, B: Type>(f: A -> B, as: List<A>): List<B>
   case as {
     nil: List.nil!,
     cons: List.cons!(f(as.head), List.map!!(f,as.tail)),

--- a/base/List/mapped.kind
+++ b/base/List/mapped.kind
@@ -1,4 +1,4 @@
-List.mapped<A: Type>(as: List(A))<B: Type>(f: A -> B): List(B)
+List.mapped<A: Type>(as: List<A>)<B: Type>(f: A -> B): List<B>
   case as {
     nil: List.nil!,
     cons: List.cons!(f(as.head),List.mapped<A>(as.tail)<B>(f))

--- a/base/List/monad.kind
+++ b/base/List/monad.kind
@@ -1,2 +1,2 @@
-List.monad: Monad(List)
+List.monad: Monad<List>
   Monad.new<List>(List.bind, List.pure)

--- a/base/List/null.kind
+++ b/base/List/null.kind
@@ -1,4 +1,4 @@
-List.null<A: Type>(xs: List(A)) : Bool
+List.null<A: Type>(xs: List<A>) : Bool
   case xs {
     nil : Bool.true,
     cons: Bool.false

--- a/base/List/or.kind
+++ b/base/List/or.kind
@@ -1,2 +1,2 @@
-List.or(list: List(Bool)): Bool
+List.or(list: List<Bool>): Bool
   List.any!((x) x)(list)

--- a/base/List/product.kind
+++ b/base/List/product.kind
@@ -1,2 +1,2 @@
-List.product(xs: List(Nat)) : Nat
+List.product(xs: List<Nat>) : Nat
   List.product.go(xs, Nat.zero)

--- a/base/List/product/go.kind
+++ b/base/List/product/go.kind
@@ -1,4 +1,4 @@
-List.product.go(xs: List(Nat), n: Nat) : Nat
+List.product.go(xs: List<Nat>, n: Nat) : Nat
   case xs {
     nil : Nat.zero,
     cons: List.product.go(xs.tail,Nat.mul(xs.head,n))

--- a/base/List/pure.kind
+++ b/base/List/pure.kind
@@ -1,2 +1,2 @@
-List.pure<A : Type>(x : A) : List(A)
+List.pure<A : Type>(x : A) : List<A>
   List.cons<A>(x)(List.nil<A>)

--- a/base/List/range.kind
+++ b/base/List/range.kind
@@ -1,2 +1,2 @@
-List.range(n: Nat): List(Nat)
+List.range(n: Nat): List<Nat>
   List.range.go(n, List.nil!)

--- a/base/List/range/go.kind
+++ b/base/List/range/go.kind
@@ -1,4 +1,4 @@
-List.range.go(n: Nat, xs: List(Nat)): List(Nat)
+List.range.go(n: Nat, xs: List<Nat>): List<Nat>
   case n {
     zero: xs,
     succ: List.range.go(n.pred, List.cons!(n, xs))

--- a/base/List/range/nat.kind
+++ b/base/List/range/nat.kind
@@ -1,2 +1,2 @@
-List.range.nat(nat: Nat): List(Nat)
+List.range.nat(nat: Nat): List<Nat>
   List.range.nat.go(nat, List.nil!)

--- a/base/List/range/nat/go.kind
+++ b/base/List/range/nat/go.kind
@@ -1,4 +1,4 @@
-List.range.nat.go(nat: Nat, list: List(Nat)): List(Nat)
+List.range.nat.go(nat: Nat, list: List<Nat>): List<Nat>
   case nat {
     zero: list,
     succ: List.range.nat.go(nat.pred, List.cons!(nat.pred, list)),

--- a/base/List/reverse.kind
+++ b/base/List/reverse.kind
@@ -1,2 +1,2 @@
-List.reverse<A: Type>(xs: List(A)) : List(A)
+List.reverse<A: Type>(xs: List<A>) : List<A>
   List.reverse.go!(xs,List.nil!)

--- a/base/List/reverse/go.kind
+++ b/base/List/reverse/go.kind
@@ -1,4 +1,4 @@
-List.reverse.go<A: Type>(xs: List(A), res: List(A)): List(A)
+List.reverse.go<A: Type>(xs: List<A>, res: List<A>): List<A>
   case xs {
     nil: res,
     cons: List.reverse.go!(xs.tail,List.cons!(xs.head,res))

--- a/base/List/run_builder.kind
+++ b/base/List/run_builder.kind
@@ -1,2 +1,2 @@
-List.run_builder<A: Type>(lb: List.Builder(A)): List(A)
+List.run_builder<A: Type>(lb: List.Builder(A)): List<A>
   lb(List.nil!)

--- a/base/List/show.kind
+++ b/base/List/show.kind
@@ -1,2 +1,2 @@
-List.show<A: Type>(f: A -> String, xs: List(A)): String
+List.show<A: Type>(f: A -> String, xs: List<A>): String
   String.flatten(["[",String.intercalate(",", List.map!!(f,xs)),"]"])

--- a/base/List/span.kind
+++ b/base/List/span.kind
@@ -1,4 +1,4 @@
-List.span<A: Type>(f: A -> Bool, xs: List(A)): Pair(List(A),List(A))
+List.span<A: Type>(f: A -> Bool, xs: List<A>): Pair<List<A>,List<A>>
   case xs {
     nil : {List.nil!, List.nil!},
     cons: case f(xs.head) {

--- a/base/List/sum.kind
+++ b/base/List/sum.kind
@@ -1,2 +1,2 @@
-List.sum(xs: List(Nat)) : Nat
+List.sum(xs: List<Nat>) : Nat
   List.sum.go(xs, Nat.zero)

--- a/base/List/sum/go.kind
+++ b/base/List/sum/go.kind
@@ -1,4 +1,4 @@
-List.sum.go(xs: List(Nat), n: Nat) : Nat
+List.sum.go(xs: List<Nat>, n: Nat) : Nat
   case xs {
     nil : n,
     cons: List.sum.go(xs.tail,Nat.add(xs.head,n))

--- a/base/List/tail.kind
+++ b/base/List/tail.kind
@@ -1,4 +1,4 @@
-List.tail<A: Type>(xs: List(A)): List(A)
+List.tail<A: Type>(xs: List<A>): List<A>
   case xs {
     nil: List.nil!,
     cons: xs.tail,

--- a/base/List/take.kind
+++ b/base/List/take.kind
@@ -1,4 +1,4 @@
-List.take<A: Type>(n: Nat, xs: List(A)): List(A)
+List.take<A: Type>(n: Nat, xs: List<A>): List<A>
   case xs {
     nil : List.nil!,
     cons: case n {

--- a/base/List/take_while.kind
+++ b/base/List/take_while.kind
@@ -1,4 +1,4 @@
-List.take_while<A: Type>(f: A -> Bool, xs: List(A)) : List(A)
+List.take_while<A: Type>(f: A -> Bool, xs: List<A>) : List<A>
   case xs{
     nil : List.nil!
     cons: case f(xs.head){

--- a/base/List/to_builder.kind
+++ b/base/List/to_builder.kind
@@ -1,2 +1,2 @@
-List.to_builder<A: Type>(list: List(A)) : List.Builder(A)
+List.to_builder<A: Type>(list: List<A>) : List.Builder(A)
   List.to_builder.go!(list, List.Builder.new!)

--- a/base/List/to_builder/go.kind
+++ b/base/List/to_builder/go.kind
@@ -1,4 +1,4 @@
-List.to_builder.go<A: Type>(list: List(A), lb: List.Builder(A)) : List.Builder(A)
+List.to_builder.go<A: Type>(list: List<A>, lb: List.Builder(A)) : List.Builder(A)
   case list {
     nil : lb,
     cons: List.to_builder.go!(list.tail, List.Builder.snoc!(list.head, lb))

--- a/base/List/uncons.kind
+++ b/base/List/uncons.kind
@@ -1,4 +1,4 @@
-List.uncons<A: Type>(xs: List(A)): Maybe(Pair(A,List(A)))
+List.uncons<A: Type>(xs: List<A>): Maybe<Pair<A,List<A>>>
   case xs {
     nil : Maybe.none!,
     cons: Maybe.some!(Pair.new!!(xs.head,xs.tail))

--- a/base/List/unfoldr.kind
+++ b/base/List/unfoldr.kind
@@ -1,2 +1,2 @@
-List.unfoldr<A: Type, B: Type>(f: A -> Maybe(Pair(A,B)), a: A): List(B)
+List.unfoldr<A: Type, B: Type>(f: A -> Maybe<Pair<A,B>>, a: A): List<B>
   List.unfoldr.go<A,B>(f, a, List.nil<B>)

--- a/base/List/unfoldr/go.kind
+++ b/base/List/unfoldr/go.kind
@@ -1,4 +1,4 @@
-List.unfoldr.go<A: Type, B: Type>(f: A -> Maybe(Pair(A,B)), a: A, bs: List(B)): List(B)
+List.unfoldr.go<A: Type, B: Type>(f: A -> Maybe<Pair<A,B>>, a: A, bs: List<B>): List<B>
   case f(a) as res {
     none: List.nil<B>,
     some: 

--- a/base/List/update_at.kind
+++ b/base/List/update_at.kind
@@ -1,4 +1,4 @@
-List.update_at<A: Type>(index: Nat, fn: A -> A, list: List(A)): List(A)
+List.update_at<A: Type>(index: Nat, fn: A -> A, list: List<A>): List<A>
   case list{
     nil : List.nil!
     cons: case index{

--- a/base/List/zip.kind
+++ b/base/List/zip.kind
@@ -1,4 +1,4 @@
-List.zip<A: Type, B: Type>(as: List(A), bs: List(B)): List(Pair(A,B))
+List.zip<A: Type, B: Type>(as: List<A>, bs: List<B>): List<Pair<A,B>>
   case as {
     nil: List.nil!,
     cons: case bs {

--- a/base/List/zip_with.kind
+++ b/base/List/zip_with.kind
@@ -1,5 +1,5 @@
-List.zip_with<A: Type, B: Type, C: Type>(f: A -> B -> C, as: List(A), bs: List(B))
-  : List(C)
+List.zip_with<A: Type, B: Type, C: Type>(f: A -> B -> C, as: List<A>, bs: List<B>)
+  : List<C>
   case as {
     nil : List.nil!,
     cons: case bs {

--- a/base/Logic/ExcludedMiddle.kind
+++ b/base/Logic/ExcludedMiddle.kind
@@ -1,2 +1,2 @@
 Logic.ExcludedMiddle(A: Type): Type
-  Either(A, Not(A))
+  Either<A, Not(A)>

--- a/base/Main.kind
+++ b/base/Main.kind
@@ -1,4 +1,4 @@
-Main: IO(Unit)
+Main: IO<Unit>
   IO {
     IO.print("Hello, world!")
   }

--- a/base/Map.kind
+++ b/base/Map.kind
@@ -1,3 +1,3 @@
 Map(V: Type): Type
-  BitsMap(V)
+  BitsMap<V>
   

--- a/base/Map/from_list.kind
+++ b/base/Map/from_list.kind
@@ -1,4 +1,4 @@
-Map.from_list<A: Type>(xs: List(Pair(String,A))): Map(A)
+Map.from_list<A: Type>(xs: List<Pair<String,A>>): Map(A)
   case xs {
     nil : BitsMap.new!,
     cons: case xs.head as p {

--- a/base/Map/get.kind
+++ b/base/Map/get.kind
@@ -1,2 +1,2 @@
-Map.get<A: Type>(key: String, map: BitsMap(A)): Maybe(A)
+Map.get<A: Type>(key: String, map: BitsMap<A>): Maybe<A>
   BitsMap.get<A>(String.to_bits(key), map)

--- a/base/Map/keys.kind
+++ b/base/Map/keys.kind
@@ -1,2 +1,2 @@
-Map.keys<A: Type>(xs: BitsMap(A)): List(String)
+Map.keys<A: Type>(xs: BitsMap<A>): List<String>
   List.mapped!(List.reverse!(BitsMap.keys.go!(xs, Bits.e, List.nil!)))!(Bits.to_string)

--- a/base/Map/query.kind
+++ b/base/Map/query.kind
@@ -1,2 +1,2 @@
-Map.query<A: Type>(cpy: A -> Pair(A, A), key: String, map: Map(A)): Pair(Map(A), Maybe(A))
+Map.query<A: Type>(cpy: A -> Pair<A, A>, key: String, map: Map(A)): Pair<Map(A), Maybe<A>>
   BitsMap.query<A>(cpy, String.to_bits(key), map)

--- a/base/Map/to_list.kind
+++ b/base/Map/to_list.kind
@@ -1,3 +1,3 @@
-Map.to_list<A: Type>(xs: Map(A)): List(Pair(String,A))
+Map.to_list<A: Type>(xs: Map(A)): List<Pair<String,A>>
   let kvs = List.reverse!(BitsMap.to_list.go!(xs, Bits.e, List.nil!))
   List.mapped!(kvs)!((kv) let {k,v} = kv; {Bits.to_string(k), v})

--- a/base/Map/values.kind
+++ b/base/Map/values.kind
@@ -1,2 +1,2 @@
-BitsMap.values<A: Type>(xs: BitsMap(A)): List(A)
+BitsMap.values<A: Type>(xs: BitsMap<A>): List<A>
   BitsMap.values.go<A>(xs, List.nil!)

--- a/base/Maybe/IsSome.kind
+++ b/base/Maybe/IsSome.kind
@@ -1,4 +1,4 @@
-Maybe.IsSome(A: Type,x: Maybe(A)): Type
+Maybe.IsSome(A: Type,x: Maybe<A>): Type
   case x{
     none: Empty
     some: A

--- a/base/Maybe/bind.kind
+++ b/base/Maybe/bind.kind
@@ -1,4 +1,4 @@
-Maybe.bind<A: Type, B: Type>(m: Maybe(A), f: A -> Maybe(B)): Maybe(B)
+Maybe.bind<A: Type, B: Type>(m: Maybe<A>, f: A -> Maybe<B>): Maybe<B>
   case m {
     none: Maybe.none<B>,
     some: f(m.value),

--- a/base/Maybe/default.kind
+++ b/base/Maybe/default.kind
@@ -1,4 +1,4 @@
-Maybe.default<A: Type>(m: Maybe(A), a: A): A
+Maybe.default<A: Type>(m: Maybe<A>, a: A): A
   case m {
     none: a,
     some: m.value,

--- a/base/Maybe/extract.kind
+++ b/base/Maybe/extract.kind
@@ -1,4 +1,4 @@
-Maybe.extract<A: Type>(m: Maybe(A))<B: Type>(a: B, f: A -> B): B
+Maybe.extract<A: Type>(m: Maybe<A>)<B: Type>(a: B, f: A -> B): B
   case m {
     none: a,
     some: f(m.value),

--- a/base/Maybe/functor.kind
+++ b/base/Maybe/functor.kind
@@ -1,2 +1,2 @@
-Maybe.functor: Functor(Maybe)
+Maybe.functor: Functor<Maybe>
   Functor.new<Maybe>(Maybe.map)

--- a/base/Maybe/join.kind
+++ b/base/Maybe/join.kind
@@ -1,4 +1,4 @@
-Maybe.join<A: Type>(m: Maybe(Maybe(A))): Maybe(A)
+Maybe.join<A: Type>(m: Maybe<Maybe<A>>): Maybe<A>
   case m{
     none: Maybe.none<A>
     some: m.value

--- a/base/Maybe/map.kind
+++ b/base/Maybe/map.kind
@@ -1,4 +1,4 @@
-Maybe.map<A: Type, B: Type>(f: A -> B, m: Maybe(A)): Maybe(B)
+Maybe.map<A: Type, B: Type>(f: A -> B, m: Maybe<A>): Maybe<B>
   case m {
     none: Maybe.none<B>,
     some: Maybe.some<B>(f(m.value)),

--- a/base/Maybe/mapped.kind
+++ b/base/Maybe/mapped.kind
@@ -1,4 +1,4 @@
-Maybe.mapped<A: Type>(m: Maybe(A))<B: Type>(f: A -> B): Maybe(B)
+Maybe.mapped<A: Type>(m: Maybe<A>)<B: Type>(f: A -> B): Maybe<B>
   case m {
     none: Maybe.none<B>,
     some: Maybe.some<B>(f(m.value)),

--- a/base/Maybe/monad.kind
+++ b/base/Maybe/monad.kind
@@ -1,2 +1,2 @@
-Maybe.monad: Monad(Maybe)
+Maybe.monad: Monad<Maybe>
   Monad.new<Maybe>(Maybe.bind, Maybe.some)

--- a/base/Maybe/or.kind
+++ b/base/Maybe/or.kind
@@ -1,4 +1,4 @@
-Maybe.or<A: Type>(a: Maybe(A), b: Maybe(A)): Maybe(A)
+Maybe.or<A: Type>(a: Maybe<A>, b: Maybe<A>): Maybe<A>
   case a {
     none: b,
     some: Maybe.some!(a.value),

--- a/base/Maybe/pure.kind
+++ b/base/Maybe/pure.kind
@@ -1,2 +1,2 @@
-Maybe.pure<A: Type>(a: A): Maybe(A)
+Maybe.pure<A: Type>(a: A): Maybe<A>
   Maybe.some<A>(a)

--- a/base/Maybe/to_bool.kind
+++ b/base/Maybe/to_bool.kind
@@ -1,4 +1,4 @@
-Maybe.to_bool<A: Type>(m: Maybe(A)): Bool
+Maybe.to_bool<A: Type>(m: Maybe<A>): Bool
   case m {
     none: Bool.false,
     some: Bool.true,

--- a/base/Monad/bind.kind
+++ b/base/Monad/bind.kind
@@ -1,4 +1,4 @@
-Monad.bind<M: Type -> Type>(m: Monad(M)): <A: Type, B: Type> -> M(A) -> (A -> M(B)) -> M(B)
+Monad.bind<M: Type -> Type>(m: Monad<M>): <A: Type, B: Type> -> M(A) -> (A -> M(B)) -> M(B)
   case m {
     new: m.bind
   }

--- a/base/Monad/pure.kind
+++ b/base/Monad/pure.kind
@@ -1,4 +1,4 @@
-Monad.pure<M: Type -> Type>(m: Monad(M)): <A: Type> -> A -> M(A)
+Monad.pure<M: Type -> Type>(m: Monad<M>): <A: Type> -> A -> M(A)
   case m {
     new: m.pure
   }

--- a/base/Mons/Attr.kind
+++ b/base/Mons/Attr.kind
@@ -4,11 +4,11 @@ type Mons.Attr {
     mhp: U32,
     atk: U32,
     name: String,
-    wlk: (x: U32) -> (y: U32) -> (obj_ani: U32) -> (obj_dir: Mons.Dir) -> List(Image3D), // walk
-    idl: List(Image3D), // idle
+    wlk: (x: U32) -> (y: U32) -> (obj_ani: U32) -> (obj_dir: Mons.Dir) -> List<Image3D>, // walk
+    idl: List<Image3D>, // idle
     pic: Image3D,
     battle_spr: (is_up: Bool) -> Image3D,
-    skills: List(Mons.Skill),
+    skills: List<Mons.Skill>,
     pos: Pos32
   )
 }

--- a/base/Mons/Attr/new_neutral.kind
+++ b/base/Mons/Attr/new_neutral.kind
@@ -1,4 +1,4 @@
-Mons.Attr.new_neutral(spr: List(Image3D)): Mons.Attr
+Mons.Attr.new_neutral(spr: List<Image3D>): Mons.Attr
   Mons.Attr.new(
     Bool.false, 0u, 0u, "",
     Mons.Kind.set_static_sprites(spr),

--- a/base/Mons/Effect.kind
+++ b/base/Mons/Effect.kind
@@ -1,10 +1,10 @@
 type Mons.Effect {
   new(
-    sleep: Pair(U32, Bool),
+    sleep: Pair<U32, Bool>,
     burn: U32, // turns that will last
-    protect: Pair(U32, Bool), // fst: if 1u, will be applied on the same turn
-    minimize: Pair(U32, Bool),
-    invulnerable: Pair(Bool, Bool), // fst: if is invulnerable, snd: if used it last turn
+    protect: Pair<U32, Bool>, // fst: if 1u, will be applied on the same turn
+    minimize: Pair<U32, Bool>,
+    invulnerable: Pair<Bool, Bool>, // fst: if is invulnerable, snd: if used it last turn
     hit: U32,
     poison: Bool,
     swap_agi: Bool)

--- a/base/Mons/Game.kind
+++ b/base/Mons/Game.kind
@@ -1,7 +1,7 @@
 type Mons.Game {
   new(
     usr: Word(160), // player name
-    pos: BitsMap(Pos32), // players positions
+    pos: BitsMap<Pos32>, // players positions
     map: Mons.Map, // the game map
     stt: Mons.Screen, // the current state of the game
     tik: U32

--- a/base/Mons/Game/get_hero_pos.kind
+++ b/base/Mons/Game/get_hero_pos.kind
@@ -1,3 +1,3 @@
-Mons.Game.get_hero_pos(game: Mons.Game): Maybe(Pos32)
+Mons.Game.get_hero_pos(game: Mons.Game): Maybe<Pos32>
   open game
   Mons.Game.get_user_pos(game.usr, game)

--- a/base/Mons/Game/get_tile.kind
+++ b/base/Mons/Game/get_tile.kind
@@ -1,3 +1,3 @@
-Mons.Game.get_tile(pos: Pos32, game: Mons.Game): List(Mons.Object)
+Mons.Game.get_tile(pos: Pos32, game: Mons.Game): List<Mons.Object>
   open game
   Mons.Map.get_list(pos, game.map)

--- a/base/Mons/Game/get_user_pos.kind
+++ b/base/Mons/Game/get_user_pos.kind
@@ -1,3 +1,3 @@
-Mons.Game.get_user_pos(user: Word(160), game: Mons.Game): Maybe(Pos32)
+Mons.Game.get_user_pos(user: Word(160), game: Mons.Game): Maybe<Pos32>
   open game
   BitsMap.get!(Word.to_bits<160>(user), game.pos)

--- a/base/Mons/Kind/get_skills.kind
+++ b/base/Mons/Kind/get_skills.kind
@@ -1,3 +1,3 @@
-Mons.Kind.get_skills(kind: Mons.Kind): List(Mons.Skill)
+Mons.Kind.get_skills(kind: Mons.Kind): List<Mons.Skill>
   open Mons.Kind.attr(kind) as attr
   attr.skills

--- a/base/Mons/Kind/new_mons.kind
+++ b/base/Mons/Kind/new_mons.kind
@@ -1,4 +1,4 @@
-Mons.Kind.new_mons(kin: Mons.Kind.mons, type: Mons.Type, agi: U32): List(Mons.Object)
+Mons.Kind.new_mons(kin: Mons.Kind.mons, type: Mons.Type, agi: U32): List<Mons.Object>
   [ Mons.Object.new_of_kind(Mons.Kind.Mons(kin, Bool.false, type, agi)),
     // Mons.Kind.new_terrain(Mons.Kind.terrain.BUSH)
     ]

--- a/base/Mons/Kind/set_pic.kind
+++ b/base/Mons/Kind/set_pic.kind
@@ -1,4 +1,4 @@
-Mons.Kind.set_pic(spr: List(Image3D)): Image3D
+Mons.Kind.set_pic(spr: List<Image3D>): Image3D
   case spr{
     nil: Image3D.empty, //Mons.Assets.void,
     cons: spr.head

--- a/base/Mons/Kind/set_static_sprites.kind
+++ b/base/Mons/Kind/set_static_sprites.kind
@@ -1,2 +1,2 @@
-Mons.Kind.set_static_sprites(spr: List(Image3D)): U32 -> U32 -> U32 -> Mons.Dir -> List(Image3D)
+Mons.Kind.set_static_sprites(spr: List<Image3D>): U32 -> U32 -> U32 -> Mons.Dir -> List<Image3D>
   (x,y,obj_ani,obj_dir) spr

--- a/base/Mons/Map.kind
+++ b/base/Mons/Map.kind
@@ -1,2 +1,2 @@
 Mons.Map: Type
-  BitsMap(List(Mons.Object))
+  BitsMap<List<Mons.Object>>

--- a/base/Mons/Map/code_to_tile/aux.kind
+++ b/base/Mons/Map/code_to_tile/aux.kind
@@ -1,4 +1,4 @@
-Mons.Map.code_to_tile.aux(code: String, cond: List(Pair(String, List(Mons.Object)))) : List(Mons.Object)
+Mons.Map.code_to_tile.aux(code: String, cond: List<Pair<String, List<Mons.Object>>>) : List<Mons.Object>
   case cond {
     nil : [],
     cons: 

--- a/base/Mons/Map/get_hero.kind
+++ b/base/Mons/Map/get_hero.kind
@@ -1,4 +1,4 @@
-Mons.Map.get_hero(pos: Pos32, map: Mons.Map): Pair(Mons.Object, U32)
+Mons.Map.get_hero(pos: Pos32, map: Mons.Map): Pair<Mons.Object, U32>
   let tile = Mons.Map.get_list(pos, map)
   let obj_is_hero = ((obj) Mons.Kind.is_hero(Mons.Object.get_kin(obj))) :: Mons.Object -> Bool 
   let fun = ((obj, idx) obj_is_hero(obj)) :: Mons.Object -> Nat -> Bool

--- a/base/Mons/Map/get_list.kind
+++ b/base/Mons/Map/get_list.kind
@@ -1,4 +1,4 @@
-Mons.Map.get_list(pos: Pos32, map: Mons.Map): List(Mons.Object)
+Mons.Map.get_list(pos: Pos32, map: Mons.Map): List<Mons.Object>
   case BitsMap.get!(U32.to_bits(pos), map) as got {
     none: [],
     some: got.value

--- a/base/Mons/Map/pop.kind
+++ b/base/Mons/Map/pop.kind
@@ -1,4 +1,4 @@
-Mons.Map.pop(pos: Pos32, map: Mons.Map): Pair(Mons.Map, Mons.Object)
+Mons.Map.pop(pos: Pos32, map: Mons.Map): Pair<Mons.Map, Mons.Object>
   let objs = Mons.Map.get_list(pos, map)
   case objs {
     nil : {map, Mons.Object.void},

--- a/base/Mons/Map/set_list.kind
+++ b/base/Mons/Map/set_list.kind
@@ -1,2 +1,2 @@
-Mons.Map.set_list(pos: Pos32, objs: List(Mons.Object), map: Mons.Map): Mons.Map
+Mons.Map.set_list(pos: Pos32, objs: List<Mons.Object>, map: Mons.Map): Mons.Map
   BitsMap.set!(U32.to_bits(pos), objs, map)

--- a/base/Mons/Object.kind
+++ b/base/Mons/Object.kind
@@ -5,10 +5,10 @@ type Mons.Object{
     pad: Mons.Pad,  // movement key pad
     ani: U32,       // number of walk frames to animate
     dmg: U32,       // object's current health points
-    bag: List(Mons.Object), // store normal Mons
+    bag: List<Mons.Object>, // store normal Mons
     mon: U32, // idx of the current Mon. Default 0u
-    bos: List(Mons.Object), // store Mons that are boss
-    cap: Pair(U32, List(Mons.Object)), // store the quantity of Mons and a copy of the captured during game
+    bos: List<Mons.Object>, // store Mons that are boss
+    cap: Pair<U32, List<Mons.Object>>, // store the quantity of Mons and a copy of the captured during game
     idl: U32, // frame for idle animation
     eff: Mons.Effect
   )

--- a/base/Mons/Object/set_bag.kind
+++ b/base/Mons/Object/set_bag.kind
@@ -1,4 +1,4 @@
-Mons.Object.set_bag(bag: List(Mons.Object), obj: Mons.Object): Mons.Object
+Mons.Object.set_bag(bag: List<Mons.Object>, obj: Mons.Object): Mons.Object
   open obj
   Mons.Object.new(obj.kin, obj.dir, obj.pad, obj.ani, obj.dmg, bag, 
     obj.mon, obj.bos, obj.cap, obj.idl, obj.eff)

--- a/base/Mons/Object/set_bos.kind
+++ b/base/Mons/Object/set_bos.kind
@@ -1,4 +1,4 @@
-Mons.Object.set_bos(bos: List(Mons.Object), obj: Mons.Object): Mons.Object
+Mons.Object.set_bos(bos: List<Mons.Object>, obj: Mons.Object): Mons.Object
   open obj 
   Mons.Object.new(obj.kin, obj.dir, obj.pad, obj.ani, obj.dmg, obj.bag, 
     obj.mon, bos, obj.cap, obj.idl, obj.eff)

--- a/base/Mons/Object/set_cap.kind
+++ b/base/Mons/Object/set_cap.kind
@@ -1,4 +1,4 @@
-Mons.Object.set_cap(cap: Pair(U32, List(Mons.Object)), obj: Mons.Object): Mons.Object
+Mons.Object.set_cap(cap: Pair<U32, List<Mons.Object>>, obj: Mons.Object): Mons.Object
   open obj
   Mons.Object.new(obj.kin, obj.dir, obj.pad, obj.ani, obj.dmg, obj.bag, 
     obj.mon, obj.bos, cap, obj.idl, obj.eff)

--- a/base/Mons/walk_char_pack.kind
+++ b/base/Mons/walk_char_pack.kind
@@ -15,7 +15,7 @@ Mons.walk_char_pack(
   u_2: Image3D,
   l_2: Image3D,
   d_2: Image3D
-): List(Image3D)
+): List<Image3D>
   //0 = parado
   //1 = pe direito pra frente
   //2 = pe esquerdo pra frente

--- a/base/Nat/div_mod.kind
+++ b/base/Nat/div_mod.kind
@@ -1,2 +1,2 @@
-Nat.div_mod(n: Nat, m: Nat): Pair(Nat, Nat)
+Nat.div_mod(n: Nat, m: Nat): Pair<Nat, Nat>
   Nat.div_mod.go(n, m, Nat.zero)

--- a/base/Nat/div_mod/go.kind
+++ b/base/Nat/div_mod/go.kind
@@ -1,4 +1,4 @@
-Nat.div_mod.go(n: Nat, m: Nat, d: Nat): Pair(Nat, Nat)
+Nat.div_mod.go(n: Nat, m: Nat, d: Nat): Pair<Nat, Nat>
   case Nat.sub_rem(n, m) as p {
     left: Nat.div_mod.go(p.value, m, Nat.succ(d)),
     right: Pair.new!!(d, n),

--- a/base/Nat/from_base.kind
+++ b/base/Nat/from_base.kind
@@ -1,2 +1,2 @@
-Nat.from_base(base: Nat, ds: List(Nat)) : Nat
+Nat.from_base(base: Nat, ds: List<Nat>) : Nat
   Nat.from_base.go(base, List.reverse!(ds),1,0)

--- a/base/Nat/from_base/go.kind
+++ b/base/Nat/from_base/go.kind
@@ -1,4 +1,4 @@
-Nat.from_base.go(b: Nat, ds: List(Nat), p: Nat, res: Nat) : Nat
+Nat.from_base.go(b: Nat, ds: List<Nat>, p: Nat, res: Nat) : Nat
   case ds {
     nil: res,
     cons: Nat.from_base.go(b,ds.tail,Nat.mul(b,p), Nat.add(Nat.mul(ds.head,p),res))

--- a/base/Nat/is_equal.kind
+++ b/base/Nat/is_equal.kind
@@ -1,4 +1,4 @@
-Nat.is_equal(a: Nat, b: Nat): Decidable(Equal(Nat, a, b))
+Nat.is_equal(a: Nat, b: Nat): Decidable<Equal<Nat, a, b>>
   case a {
     zero: case b {
       zero: Decidable.yep!(refl)
@@ -11,4 +11,4 @@ Nat.is_equal(a: Nat, b: Nat): Decidable(Equal(Nat, a, b))
         nop: Decidable.nop!((e) dec.proof(apply(Nat.pred, e)))
       }!
     }!
-  }: Decidable(Equal(Nat, a, b))
+  }: Decidable<Equal<Nat, a, b>>

--- a/base/Nat/sub_rem.kind
+++ b/base/Nat/sub_rem.kind
@@ -1,4 +1,4 @@
-Nat.sub_rem(n: Nat, m: Nat): Either(Nat, Nat)
+Nat.sub_rem(n: Nat, m: Nat): Either<Nat, Nat>
   case m {
     zero: Either.left!!(n),
     succ: case n {

--- a/base/Nat/succ_neq_zero.kind
+++ b/base/Nat/succ_neq_zero.kind
@@ -1,2 +1,2 @@
-Nat.succ_neq_zero(a: Nat): Not(Equal(Nat, Nat.succ(a), 0))
+Nat.succ_neq_zero(a: Nat): Not(Equal<Nat, Nat.succ(a), 0>)
   (e) Bool.false_neq_true(apply(Nat.is_zero, e))

--- a/base/Nat/to_base.kind
+++ b/base/Nat/to_base.kind
@@ -1,2 +1,2 @@
-Nat.to_base(base: Nat, nat: Nat): List(Nat)
+Nat.to_base(base: Nat, nat: Nat): List<Nat>
   Nat.to_base.go(base, nat, List.nil<Nat>)

--- a/base/Nat/to_base/go.kind
+++ b/base/Nat/to_base/go.kind
@@ -1,4 +1,4 @@
-Nat.to_base.go(base: Nat, nat: Nat, res: List(Nat)): List(Nat)
+Nat.to_base.go(base: Nat, nat: Nat, res: List<Nat>): List<Nat>
   case Nat.div_mod(nat, base) as div_mod {
     new: case div_mod.fst {
       zero: List.cons!(div_mod.snd, res),

--- a/base/Nat/to_fin.kind
+++ b/base/Nat/to_fin.kind
@@ -1,4 +1,4 @@
-Nat.to_fin(n: Nat)<sobra: Nat>: Fin(Nat.succ(Nat.add(n, sobra)))
+Nat.to_fin(n: Nat)<sobra: Nat>: Fin<Nat.succ(Nat.add(n, sobra))>
   case n {
     zero:
       Fin.zero<sobra>

--- a/base/Nat/zero_neq_succ.kind
+++ b/base/Nat/zero_neq_succ.kind
@@ -1,2 +1,2 @@
-Nat.zero_neq_succ(a: Nat): Not(Equal(Nat, 0, Nat.succ(a)))
+Nat.zero_neq_succ(a: Nat): Not(Equal<Nat, 0, Nat.succ(a)>)
   (e) Bool.true_neq_false(apply(Nat.is_zero, e))

--- a/base/Pair/fst.kind
+++ b/base/Pair/fst.kind
@@ -1,4 +1,4 @@
-Pair.fst<A: Type, B: Type>(pair: Pair(A, B)): A
+Pair.fst<A: Type, B: Type>(pair: Pair<A, B>): A
   case pair {
     new: pair.fst
   }

--- a/base/Pair/functor.kind
+++ b/base/Pair/functor.kind
@@ -1,2 +1,2 @@
-Pair.functor<A: Type>: Functor(Pair(A))
-  Functor.new<Pair(A)>(Pair.map<A>)
+Pair.functor<A: Type>: Functor<Pair<A>>
+  Functor.new<Pair<A>>(Pair.map<A>)

--- a/base/Pair/map.kind
+++ b/base/Pair/map.kind
@@ -1,4 +1,4 @@
-Pair.map<A: Type, B: Type, C: Type>(f: B -> C, p: Pair(A, B)): Pair(A, C)
+Pair.map<A: Type, B: Type, C: Type>(f: B -> C, p: Pair<A, B>): Pair<A, C>
   case p {
     new: Pair.new<A, C>(p.fst, f(p.snd))
   }

--- a/base/Pair/show.kind
+++ b/base/Pair/show.kind
@@ -1,7 +1,7 @@
 Pair.show<A: Type, B: Type>(
   show_a: A -> String,
   show_b: B -> String,
-  pair: Pair(A,B)
+  pair: Pair<A,B>
 ) : String
   case pair{
     new: let str = String.concat("(", show_a(pair.fst))

--- a/base/Pair/snd.kind
+++ b/base/Pair/snd.kind
@@ -1,4 +1,4 @@
-Pair.snd<A: Type, B: Type>(pair: Pair(A, B)): B
+Pair.snd<A: Type, B: Type>(pair: Pair<A, B>): B
   case pair {
     new: pair.snd
   }

--- a/base/Parser.kind
+++ b/base/Parser.kind
@@ -1,2 +1,2 @@
 Parser(V: Type): Type
-  Nat -> String -> Parser.Reply(V)
+  Nat -> String -> Parser.Reply<V>

--- a/base/Parser/ErrorAt/combine.kind
+++ b/base/Parser/ErrorAt/combine.kind
@@ -1,7 +1,7 @@
 Parser.ErrorAt.combine(
-  a: Maybe(Parser.ErrorAt),
-  b: Maybe(Parser.ErrorAt),
-): Maybe(Parser.ErrorAt)
+  a: Maybe<Parser.ErrorAt>,
+  b: Maybe<Parser.ErrorAt>,
+): Maybe<Parser.ErrorAt>
   case a {
     none: b,
     some: case b {

--- a/base/Parser/first_of.kind
+++ b/base/Parser/first_of.kind
@@ -1,2 +1,2 @@
-Parser.first_of<A: Type>(pars: List(Parser(A))): Parser(A)
+Parser.first_of<A: Type>(pars: List<Parser(A)>): Parser(A)
   Parser.first_of.go<A>(pars, Maybe.none!)

--- a/base/Parser/first_of/go.kind
+++ b/base/Parser/first_of/go.kind
@@ -1,4 +1,4 @@
-Parser.first_of.go<A: Type>(pars: List(Parser(A)), err: Maybe(Parser.ErrorAt)): Parser(A)
+Parser.first_of.go<A: Type>(pars: List<Parser(A)>, err: Maybe<Parser.ErrorAt>): Parser(A)
   (idx,code) 
     case pars {
       nil: case err {

--- a/base/Parser/many.kind
+++ b/base/Parser/many.kind
@@ -1,2 +1,2 @@
-Parser.many<V: Type>(parser: Parser(V)): Parser(List(V))
+Parser.many<V: Type>(parser: Parser(V)): Parser(List<V>)
   Parser.many.go<V>(parser, (x) x)

--- a/base/Parser/many/go.kind
+++ b/base/Parser/many/go.kind
@@ -1,5 +1,5 @@
-Parser.many.go<V: Type>(parse: Parser(V), values: List(V) -> List(V), idx: Nat, code: String): Parser.Reply(List(V))
+Parser.many.go<V: Type>(parse: Parser(V), values: List<V> -> List<V>, idx: Nat, code: String): Parser.Reply<List<V>>
   case parse(idx,code) as reply {
-    error: Parser.Reply.value<List(V)>(idx, code, values([])),
+    error: Parser.Reply.value<List<V>>(idx, code, values([])),
     value: Parser.many.go<V>(parse, (xs) values(List.cons!(reply.val, xs)), reply.idx, reply.code),
   }

--- a/base/Parser/many1.kind
+++ b/base/Parser/many1.kind
@@ -1,4 +1,4 @@
-Parser.many1<V: Type>(parser: Parser(V)): Parser(List(V))
+Parser.many1<V: Type>(parser: Parser(V)): Parser(List<V>)
   Parser {
     var head = parser;
     var tail = Parser.many<V>(parser);

--- a/base/Parser/maybe.kind
+++ b/base/Parser/maybe.kind
@@ -1,5 +1,5 @@
-Parser.maybe<V: Type>(parse: Parser(V)): Parser(Maybe(V))
+Parser.maybe<V: Type>(parse: Parser(V)): Parser(Maybe<V>)
   (idx,code) case parse(idx,code) as reply {
-    error: Parser.Reply.value<Maybe(V)>(idx, code, Maybe.none<V>),
-    value: Parser.Reply.value<Maybe(V)>(reply.idx, reply.code, Maybe.some<V>(reply.val)),
+    error: Parser.Reply.value<Maybe<V>>(idx, code, Maybe.none<V>),
+    value: Parser.Reply.value<Maybe<V>>(reply.idx, reply.code, Maybe.some<V>(reply.val)),
   }

--- a/base/Parser/monad.kind
+++ b/base/Parser/monad.kind
@@ -1,2 +1,2 @@
-Parser.monad: Monad(Parser)
+Parser.monad: Monad<Parser>
   Monad.new<Parser>(Parser.bind, Parser.pure)

--- a/base/Parser/run.kind
+++ b/base/Parser/run.kind
@@ -1,4 +1,4 @@
-Parser.run<A: Type>(parser: Parser(A), code: String): Maybe(A)
+Parser.run<A: Type>(parser: Parser(A), code: String): Maybe<A>
   case parser(0, code) as parsed {
     error: none
     value: some(parsed.val)

--- a/base/Parser/spaces.kind
+++ b/base/Parser/spaces.kind
@@ -1,4 +1,4 @@
-Parser.spaces: Parser(List(Unit))
+Parser.spaces: Parser(List<Unit>)
   Parser.many!(Parser.first_of!([
     Parser.text(" "),
     Parser.text("\n"),

--- a/base/Parser/until.kind
+++ b/base/Parser/until.kind
@@ -1,2 +1,2 @@
-Parser.until<V: Type>(until: Parser(Unit), parse: Parser(V)): Parser(List(V))
+Parser.until<V: Type>(until: Parser(Unit), parse: Parser(V)): Parser(List<V>)
   Parser.until.go<V>(until, parse, [])

--- a/base/Parser/until/go.kind
+++ b/base/Parser/until/go.kind
@@ -1,21 +1,21 @@
 Parser.until.go<V: Type>(
   until: Parser(Unit),
   parse: Parser(V),
-  values: List(V),
+  values: List<V>,
   idx: Nat,
   code: String
-): Parser.Reply(List(V))
+): Parser.Reply<List<V>>
   let until_reply = until(idx,code);
   case until_reply {
     error:
       let reply = parse(idx,code);
       case reply {
         error:
-          Parser.Reply.error<List(V)>(reply.idx, reply.code, reply.err),
+          Parser.Reply.error<List<V>>(reply.idx, reply.code, reply.err),
         value:
           def values = List.cons<V>(reply.val, values)
           Parser.until.go<V>(until, parse, values, reply.idx, reply.code)
       }
     value:
-      Parser.Reply.value<List(V)>(until_reply.idx, until_reply.code, List.reverse<V>(values)),
+      Parser.Reply.value<List<V>>(until_reply.idx, until_reply.code, List.reverse<V>(values)),
   }

--- a/base/Parser/until1.kind
+++ b/base/Parser/until1.kind
@@ -1,4 +1,4 @@
-Parser.until1<V: Type>(cond: Parser(Unit), parser: Parser(V)): Parser(List(V))
+Parser.until1<V: Type>(cond: Parser(Unit), parser: Parser(V)): Parser(List<V>)
   Parser {
     var head = parser;
     var tail = Parser.until<V>(cond, parser);

--- a/base/Problems.kind
+++ b/base/Problems.kind
@@ -70,11 +70,11 @@
 //  ?a
 
 // Returns the first element of a List
-//Problems.p14<A: Type>(xs: List<A>): Maybe(A)
+//Problems.p14<A: Type>(xs: List<A>): Maybe<A>
 //  ?a
 
 // Returns the list without the first element
-//Problems.p15<A: Type>(xs: List<A>): List(A)
+//Problems.p15<A: Type>(xs: List<A>): List<A>
 //  ?a
 
 // Returns the length of a list

--- a/base/Queue.kind
+++ b/base/Queue.kind
@@ -1,3 +1,3 @@
 type Queue<A: Type> {
-  new(front: List(A), size_front: Nat, rear: List(A), size_rear: Nat)
+  new(front: List<A>, size_front: Nat, rear: List<A>, size_rear: Nat)
 }

--- a/base/Queue/balance.kind
+++ b/base/Queue/balance.kind
@@ -1,4 +1,4 @@
-Queue.balance<A: Type>(f: List(A), sf: Nat, r: List(A), sr: Nat): Queue(A)
+Queue.balance<A: Type>(f: List<A>, sf: Nat, r: List<A>, sr: Nat): Queue<A>
   let max_sf = Nat.add(1, Nat.mul(Queue.max_diff, sf))
   let max_sr = Nat.add(1, Nat.mul(Queue.max_diff, sr))
   let size1 = Nat.div(Nat.add(sf, sr), 2)

--- a/base/Queue/cons.kind
+++ b/base/Queue/cons.kind
@@ -1,4 +1,4 @@
-Queue.cons<A: Type>(a: A, q: Queue(A)): Queue(A)
+Queue.cons<A: Type>(a: A, q: Queue<A>): Queue<A>
   open q
   let new_f = List.cons<A>(a, q.front)
   let new_sf = Nat.add(q.size_front, 1)

--- a/base/Queue/empty.kind
+++ b/base/Queue/empty.kind
@@ -1,2 +1,2 @@
-Queue.empty<A: Type>: Queue(A)
+Queue.empty<A: Type>: Queue<A>
   Queue.new<A>(List.nil<A>, 0, List.nil<A>, 0)

--- a/base/Queue/foldr.kind
+++ b/base/Queue/foldr.kind
@@ -1,4 +1,4 @@
-Queue.foldr<A: Type, B: Type>(b: B, f: A -> B -> B, q: Queue(A)): B 
+Queue.foldr<A: Type, B: Type>(b: B, f: A -> B -> B, q: Queue<A>): B 
   open q
   let as_list = List.concat<A>(q.front, List.reverse<A>(q.rear))
   List.foldr<A,B>(b, f, as_list)

--- a/base/Queue/from_list.kind
+++ b/base/Queue/from_list.kind
@@ -1,3 +1,3 @@
-Queue.from_list<A: Type>(as: List(A)): Queue(A)
+Queue.from_list<A: Type>(as: List<A>): Queue<A>
   let len = List.length<A>(as)
   Queue.balance<A>(as, len, List.nil<A>, 0)

--- a/base/Queue/head.kind
+++ b/base/Queue/head.kind
@@ -1,4 +1,4 @@
-Queue.head<A: Type>(q: Queue(A)): Maybe(A)
+Queue.head<A: Type>(q: Queue<A>): Maybe<A>
   open q
   case q.front {
     nil : Maybe.none<A>,

--- a/base/Queue/init.kind
+++ b/base/Queue/init.kind
@@ -1,17 +1,17 @@
-Queue.init<A: Type>(q: Queue(A)): Maybe(Queue(A))
+Queue.init<A: Type>(q: Queue<A>): Maybe<Queue<A>>
   open q
   case q.rear {
     nil: case q.front {
-      nil : Maybe.none<Queue(A)>,
+      nil : Maybe.none<Queue<A>>,
       cons: 
         let new_f  = List.drop<A>(1, q.front)
         let new_sf = Nat.sub(q.size_front, 1)
         let new_q  = Queue.balance<A>(new_f, new_sf, List.nil<A>, 0)
-        Maybe.some<Queue(A)>(new_q)
+        Maybe.some<Queue<A>>(new_q)
     },
     cons:
       let new_r  = List.drop<A>(1, q.rear)
       let new_sr = Nat.sub(q.size_rear, 1)
       let new_q  = Queue.balance<A>(q.front, q.size_front, new_r, new_sr)
-      Maybe.some<Queue(A)>(new_q)
+      Maybe.some<Queue<A>>(new_q)
   }

--- a/base/Queue/last.kind
+++ b/base/Queue/last.kind
@@ -1,4 +1,4 @@
-Queue.last<A: Type>(q: Queue(A)): Maybe(A)
+Queue.last<A: Type>(q: Queue<A>): Maybe<A>
   open q
   case q.rear {
     nil: case q.front {

--- a/base/Queue/length.kind
+++ b/base/Queue/length.kind
@@ -1,3 +1,3 @@
-Queue.length<A: Type>(q: Queue(A)): Nat 
+Queue.length<A: Type>(q: Queue<A>): Nat 
   open q
   Nat.add(q.size_front, q.size_rear)

--- a/base/Queue/map.kind
+++ b/base/Queue/map.kind
@@ -1,4 +1,4 @@
-Queue.map<A: Type, B: Type>(f: A -> B, q: Queue(A)): Queue(B)
+Queue.map<A: Type, B: Type>(f: A -> B, q: Queue<A>): Queue<B>
   open q
   let new_f = List.map!!(f, q.front)
   let new_r = List.map!!(f, q.rear)

--- a/base/Queue/null.kind
+++ b/base/Queue/null.kind
@@ -1,4 +1,4 @@
-Queue.null<A: Type>(q: Queue(A)): Bool
+Queue.null<A: Type>(q: Queue<A>): Bool
   open q
   let front_is_empty = Nat.eql(q.size_front, 0)
   let rear_is_empty  = Nat.eql(q.size_rear, 0)

--- a/base/Queue/snoc.kind
+++ b/base/Queue/snoc.kind
@@ -1,4 +1,4 @@
-Queue.snoc<A: Type>(a: A, q: Queue(A)): Queue(A)
+Queue.snoc<A: Type>(a: A, q: Queue<A>): Queue<A>
   open q
   let new_rear = List.cons<A>(a, q.rear)
   Queue.balance<A>(q.front, q.size_front, new_rear, Nat.add(q.size_rear, 1))

--- a/base/Queue/tail.kind
+++ b/base/Queue/tail.kind
@@ -1,9 +1,9 @@
-Queue.tail<A: Type>(q: Queue(A)): Maybe(Queue(A))
+Queue.tail<A: Type>(q: Queue<A>): Maybe<Queue<A>>
   open q
   case q.front {
-    nil : Maybe.none<Queue(A)>,
+    nil : Maybe.none<Queue<A>>,
     cons: 
       let new_front = List.drop<A>(1, q.front)
       let new_q = Queue.balance<A>(new_front, Nat.sub(q.size_front, 1), q.rear, q.size_rear)
-      Maybe.some<Queue(A)>(new_q)
+      Maybe.some<Queue<A>>(new_q)
   }

--- a/base/Queue/to_list.kind
+++ b/base/Queue/to_list.kind
@@ -1,3 +1,3 @@
-Queue.to_list<A: Type>(q: Queue(A)): List(A)
+Queue.to_list<A: Type>(q: Queue<A>): List<A>
   open q
   List.concat<A>(q.front, List.reverse<A>(q.rear))

--- a/base/String/flatten.kind
+++ b/base/String/flatten.kind
@@ -1,2 +1,2 @@
-String.flatten(xs: List(String)): String
+String.flatten(xs: List<String>): String
   String.flatten.go(xs, "")

--- a/base/String/flatten/go.kind
+++ b/base/String/flatten/go.kind
@@ -1,4 +1,4 @@
-String.flatten.go(xs: List(String), res: String): String
+String.flatten.go(xs: List<String>, res: String): String
   case xs {
     nil: res,
     cons: String.flatten.go(xs.tail, String.concat(res, xs.head)),

--- a/base/String/from_list.kind
+++ b/base/String/from_list.kind
@@ -1,4 +1,4 @@
-String.from_list(xs: List(Char)) : String
+String.from_list(xs: List<Char>) : String
   case xs{
     nil : String.nil
     cons: String.cons(xs.head,String.from_list(xs.tail))

--- a/base/String/head.kind
+++ b/base/String/head.kind
@@ -1,4 +1,4 @@
-String.head(xs: String): Maybe(Char)
+String.head(xs: String): Maybe<Char>
   case xs{
     nil : Maybe.none!
     cons: Maybe.some!(xs.head)

--- a/base/String/intercalate.kind
+++ b/base/String/intercalate.kind
@@ -1,2 +1,2 @@
-String.intercalate(sep: String, xs: List(String)): String
+String.intercalate(sep: String, xs: List<String>): String
   String.flatten(List.intersperse!(sep,xs))

--- a/base/String/join.kind
+++ b/base/String/join.kind
@@ -1,2 +1,2 @@
-String.join(sep: String, list: List(String)): String
+String.join(sep: String, list: List<String>): String
   String.join.go(sep, list, Bool.true)

--- a/base/String/join/go.kind
+++ b/base/String/join/go.kind
@@ -1,4 +1,4 @@
-String.join.go(sep: String, list: List(String), fst: Bool): String
+String.join.go(sep: String, list: List<String>, fst: Bool): String
   case list {
     nil: "",
     cons: String.flatten([

--- a/base/String/span.kind
+++ b/base/String/span.kind
@@ -1,4 +1,4 @@
-String.span(f: Char -> Bool, xs: String): Pair(String,String)
+String.span(f: Char -> Bool, xs: String): Pair<String,String>
   case xs{
     nil : Pair.new!!(String.nil,String.nil)
     cons: case f(xs.head){

--- a/base/String/split.kind
+++ b/base/String/split.kind
@@ -1,2 +1,2 @@
-String.split(xs: String, match: String): List(String)
+String.split(xs: String, match: String): List<String>
   String.split.go(xs, match, "")

--- a/base/String/split/go.kind
+++ b/base/String/split/go.kind
@@ -1,4 +1,4 @@
-String.split.go(xs: String, match: String, last: String): List(String)
+String.split.go(xs: String, match: String, last: String): List<String>
   case xs {
     nil:
       [last]

--- a/base/String/to_list.kind
+++ b/base/String/to_list.kind
@@ -1,4 +1,4 @@
-String.to_list(str: String): List(Char)
+String.to_list(str: String): List<Char>
   case str{
     nil : List.nil!
     cons: List.cons!(str.head, String.to_list(str.tail))

--- a/base/User/MaiaVictor/Problems.kind
+++ b/base/User/MaiaVictor/Problems.kind
@@ -123,14 +123,14 @@ Problems.p13(a: Nat, b: Nat): Bool
   }
 
 // Returns the first element of a List
-Problems.p14<A: Type>(xs: List<A>): Maybe(A)
+Problems.p14<A: Type>(xs: List<A>): Maybe<A>
   case xs {
     nil: none
     cons: some(xs.head)
   }
 
 // Returns the list without the first element
-Problems.p15<A: Type>(xs: List<A>): List(A)
+Problems.p15<A: Type>(xs: List<A>): List<A>
   case xs {
     nil: []
     cons: xs.tail

--- a/base/Vector.kind
+++ b/base/Vector.kind
@@ -1,4 +1,4 @@
 type Vector <A: Type>                           ~ (size: Nat) {
   nil                                           ~ (size = Nat.zero),
-  ext<size: Nat>(head: A, tail: Vector(A,size)) ~ (size = Nat.succ(size)),
+  ext<size: Nat>(head: A, tail: Vector<A,size>) ~ (size = Nat.succ(size)),
 }

--- a/base/Vector/from_list.kind
+++ b/base/Vector/from_list.kind
@@ -1,4 +1,4 @@
-Vector.from_list<A: Type>(xs: List(A)): Vector(A, List.length<A>(xs))
+Vector.from_list<A: Type>(xs: List<A>): Vector<A, List.length<A>(xs)>
   case xs {
     nil  : Vector.nil<A>
     cons : Vector.ext<A>(_, xs.head, Vector.from_list<A>(xs.tail))

--- a/base/Vector/head.kind
+++ b/base/Vector/head.kind
@@ -1,4 +1,4 @@
-Vector.head<A: Type, size: Nat>(vector: Vector(A, Nat.succ(size))): A
+Vector.head<A: Type, size: Nat>(vector: Vector<A, Nat.succ(size)>): A
   case vector {
     nil: Unit.new
     ext: vector.head

--- a/base/Vector/tail.kind
+++ b/base/Vector/tail.kind
@@ -1,5 +1,5 @@
-Vector.tail<A: Type, size: Nat>(vector: Vector(A, Nat.succ(size))): Vector(A, size)
+Vector.tail<A: Type, size: Nat>(vector: Vector<A, Nat.succ(size)>): Vector<A, size>
   case vector {
     nil: Unit.new
     ext: vector.tail
-  }: case vector.size { zero: Unit, succ: Vector(A, Nat.pred(vector.size)) }
+  }: case vector.size { zero: Unit, succ: Vector<A, Nat.pred(vector.size)> }

--- a/base/Web/Demo.kind
+++ b/base/Web/Demo.kind
@@ -1,5 +1,5 @@
 // A demo application that renders a square on the screen
-Web.Demo: App(Pair(U32,U32))
+Web.Demo: App<Pair<U32,U32>>
   // Allocates the mutable buffer
   let img = Image3D.alloc_capacity(256u)
 

--- a/base/Web/Jogo.kind
+++ b/base/Web/Jogo.kind
@@ -1,5 +1,5 @@
 Web.Jogo.State: Type
-  BitsMap(Pair(U32, U32))
+  BitsMap<Pair<U32, U32>>
 
 Web.Jogo.room: String
   "0x196581625482"
@@ -39,7 +39,7 @@ Web.Jogo.command(user: String, cmd: String, state: Web.Jogo.State): Web.Jogo.Sta
   }
 
 // A demo application that renders a square on the screen
-Web.Jogo: App(Web.Jogo.State)
+Web.Jogo: App<Web.Jogo.State>
   let img = Image3D.alloc_capacity(3200u)
   let init = BitsMap.new!
   let draw = (state)

--- a/blog/0-goodbye-javascript.md
+++ b/blog/0-goodbye-javascript.md
@@ -42,7 +42,7 @@ This will install the `fmhs` command in your machine, which is identical to
 commands should output:
 
 ```bash
-Main: IO(Unit)
+Main: IO<Unit>
 
 All terms check.
 ```


### PR DESCRIPTION
This PR refactors following types to use angle brackets:

- App
- App.Action
- Array
- BitsMap
- Decidable
- Either
- Equal
- Fin
- Functor
- GMap
- GSet
- IO
- Kind.Check
- List
- Maybe
- Monad
- Pair
- Parser.Reply
- Queue
- The
- Vector

I can remove types if needed or add some others.