### PR TITLE
Adds two functions to GMap 

### DIFF
--- a/base/GMap/delete.kind
+++ b/base/GMap/delete.kind
@@ -1,0 +1,26 @@
+GMap.delete<K: Type, V: Type>(
+  key: K, 
+  map: GMap<K, V>, 
+  cmp : K -> K -> Cmp
+) : GMap<K, V>
+  case map {
+    tip: GMap.tip!!
+    bin: 
+      case cmp(key, map.key) {
+        // when recursion comes back rebalance the node
+        ltn: GMap.balance!!(map.key, map.val, GMap.delete!!(key, map.left, cmp), map.right)
+        // when recursion comes back rebalance the node
+        gtn: GMap.balance!!(map.key, map.val, map.left, GMap.delete!!(key, map.right, cmp))
+        eql: 
+          // get min value from right subtree
+          let min = GMap.min!!(map.right)
+          case min {
+            //no nodes on right, return left; if left is empty then will return empty anyway
+            none: map.left
+            some:
+                open min.value
+                let right_without_min = GMap.delete_min!!(map.right) // deletes right's min, rebalancing this subtree
+                GMap.balance!!(min.value.fst, min.value.snd, map.left, right_without_min) // rebalance his own node with the new right tree
+          }!
+      }!
+  }!

--- a/base/GMap/show_tree.kind
+++ b/base/GMap/show_tree.kind
@@ -1,0 +1,6 @@
+GMap.show_tree<K: Type, V: Type>(
+  tree: GMap<K,V>, 
+  key_show: K -> String, 
+  val_show: V -> String
+) : String
+  GMap.show_tree.go!!(tree, key_show, val_show, 0)

--- a/base/GMap/show_tree/go.kind
+++ b/base/GMap/show_tree/go.kind
@@ -1,0 +1,18 @@
+GMap.show_tree.go<K: Type, V: Type>(
+  tree: GMap<K,V>, 
+  key_show: K -> String, 
+  val_show: V -> String, 
+  nivel: Nat
+) : String
+  case tree {
+    tip:  Nat.apply<String>(nivel, String.concat(" "), "") | "_\n"
+    bin:       
+      let result = Nat.apply<String>(nivel, String.concat(" "), "") 
+                    | key_show(tree.key) 
+                    | " : " 
+                    | val_show(tree.val) 
+                    | "\n"
+      result 
+        | GMap.show_tree.go!!(tree.left, key_show, val_show, nivel+1) 
+        | GMap.show_tree.go!!(tree.right, key_show, val_show, nivel+1)
+  }!


### PR DESCRIPTION
Adds delete and show_tree function to `GMap`.
`delete(key, map, cmp)` will remove the node with the respective key from the map.
`show_tree(map, show_key, show_val)` will print (convert to string) the `GMap` as an idented tree, following the pattern middle-left-right.