### PR TITLE
Update Usage commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Usage
 
 ```bash
 npm i -g kind-lang                             # installs Kind
-git clone https://github.com/uwu-tech/kind     # clones base libs
+git clone https://github.com/uwu-tech/Kind     # clones base libs
 cd Kind/base                                   # enters base libs
 kind Main                                      # checks Main.kind
 kind Main --run                                # runs Main


### PR DESCRIPTION
Right now executing commands from `Usage` section will cause an error. Either git clone should clone repo to `Kind` dir or `cd Kind/base` should become `cd kind/base`.