### PR TITLE
Fix 'case default' error with no space after it

### DIFF
--- a/base/Kind/Parser/case.kind
+++ b/base/Kind/Parser/case.kind
@@ -26,7 +26,7 @@ Kind.Parser.case: Parser(Kind.Term)
 
     // Default value
     get dflt = Parser.maybe!(Parser {
-      Kind.Parser.text("default ");
+      Kind.Parser.text("default");
       get term = Kind.Parser.term;
       return term;
     });


### PR DESCRIPTION
**Problem**: when using a `default` without space after its name caused an error: 
```
case event {
   ...
} default
  App.pass

----
Expected ':', found 'A'.
  67 |     App.pass
```
To solve it:
```
case event {
   ...
} default App.pass
```

**Solution proposal**: remove the required space after `default` name.