### PR TITLE
fix all calls to Word.is_neg

### DIFF
--- a/base/I128/is_neg.kind
+++ b/base/I128/is_neg.kind
@@ -1,3 +1,3 @@
 I128.is_neg(a: I128): Bool
   open a
-  Word.is_neg!(a.value, false)
+  Word.is_neg!(a.value)

--- a/base/I16/is_neg.kind
+++ b/base/I16/is_neg.kind
@@ -1,3 +1,3 @@
 I16.is_neg(a: I16): Bool
   open a
-  Word.is_neg!(a.value, false)
+  Word.is_neg!(a.value)

--- a/base/I256/is_neg.kind
+++ b/base/I256/is_neg.kind
@@ -1,3 +1,3 @@
 I256.is_neg(a: I256): Bool
   open a
-  Word.is_neg!(a.value, false)
+  Word.is_neg!(a.value)

--- a/base/I32/is_neg.kind
+++ b/base/I32/is_neg.kind
@@ -1,3 +1,3 @@
 I32.is_neg(a: I32): Bool
   open a
-  Word.is_neg!(a.value, false)
+  Word.is_neg!(a.value)

--- a/base/I64/is_neg.kind
+++ b/base/I64/is_neg.kind
@@ -1,3 +1,3 @@
 I64.is_neg(a: I64): Bool
   open a
-  Word.is_neg!(a.value, false)
+  Word.is_neg!(a.value)

--- a/base/I8/is_neg.kind
+++ b/base/I8/is_neg.kind
@@ -1,3 +1,3 @@
 I8.is_neg(a: I8): Bool
   open a
-  Word.is_neg!(a.value, false)
+  Word.is_neg!(a.value)

--- a/base/Word/s_cmp.kind
+++ b/base/Word/s_cmp.kind
@@ -1,7 +1,7 @@
 // the s stands for signed comparison
 Word.s_cmp<size: Nat>(a: Word(size), b: Word(size)): Cmp
-  a_neg = Word.is_neg!(a, false)
-  b_neg = Word.is_neg!(b, false)
+  a_neg = Word.is_neg!(a)
+  b_neg = Word.is_neg!(b)
   case a_neg b_neg {
     false false: Word.cmp!(a, b)
     false true: Cmp.gtn

--- a/base/Word/s_gte.kind
+++ b/base/Word/s_gte.kind
@@ -1,6 +1,6 @@
 Word.s_gte<size:Nat>(a: Word(size), b: Word(size)): Bool
-  let neg_a = Word.is_neg!(a, false)
-  let neg_b = Word.is_neg!(b, false)
+  let neg_a = Word.is_neg!(a)
+  let neg_b = Word.is_neg!(b)
   case neg_a neg_b {
     false false: Cmp.as_gte(Word.cmp<size>(a, b))
     false true: true

--- a/base/Word/s_lte.kind
+++ b/base/Word/s_lte.kind
@@ -1,6 +1,6 @@
 Word.s_lte<size:Nat>(a: Word(size), b: Word(size)): Bool
-  let neg_a = Word.is_neg!(a, false)
-  let neg_b = Word.is_neg!(b, false)
+  let neg_a = Word.is_neg!(a)
+  let neg_b = Word.is_neg!(b)
   case neg_a neg_b {
     false false: Cmp.as_lte(Word.cmp<size>(a, b))
     false true: false

--- a/base/Word/s_pow.kind
+++ b/base/Word/s_pow.kind
@@ -1,5 +1,5 @@
 Word.s_pow<size: Nat>(a: Word(size), b: Word(size)): Word(size)
-  case Word.is_neg!(b, false) as neg {
+  case Word.is_neg!(b) as neg {
     true: Word.zero!
     false: Word.pow!(a, b)
   }

--- a/base/Word/s_shl.kind
+++ b/base/Word/s_shl.kind
@@ -1,5 +1,5 @@
 Word.s_shl<size: Nat>(n: Word(size), value: Word(size)): Word(size)
-  neg = Word.is_neg!(n, false)
+  neg = Word.is_neg!(n)
   case neg {
     false: Word.shl!(n, value)
     true: n = Word.neg!(n)

--- a/base/Word/s_shr.kind
+++ b/base/Word/s_shr.kind
@@ -1,5 +1,5 @@
 Word.s_shr<size: Nat>(n: Word(size), value: Word(size)): Word(size)
-  neg = Word.is_neg!(n, false)
+  neg = Word.is_neg!(n)
   case neg {
     false: Word.shr!(n, value)
     true: n = Word.neg!(n)

--- a/base/Word/s_sqrt.kind
+++ b/base/Word/s_sqrt.kind
@@ -1,5 +1,5 @@
 Word.s_sqrt<size: Nat>(a: Word(size)): Word(size)
-  neg = Word.is_neg!(a, false)
+  neg = Word.is_neg!(a)
   if neg then
     Word.zero!
   else


### PR DESCRIPTION
The function Word.is_neg was changed but the calls for it wasn't. Previously the function received two parameters; then the second parameter was hidden inside an auxiliar function, but the calls to the original function was not changed. 