### PR TITLE
Add a Buffer8 type

### DIFF
--- a/base/Buffer8.kind
+++ b/base/Buffer8.kind
@@ -1,0 +1,3 @@
+type Buffer8 {
+  new(depth: Nat, array: Array<U8, depth>)
+}

--- a/base/Buffer8/alloc.kind
+++ b/base/Buffer8/alloc.kind
@@ -1,0 +1,2 @@
+Buffer8.alloc(depth: Nat): Buffer8
+  Buffer8.new(depth, Array.alloc<U8>(depth, U8.zero))

--- a/base/Buffer8/get.kind
+++ b/base/Buffer8/get.kind
@@ -1,0 +1,5 @@
+Buffer8.get(idx: U32, buf: Buffer8): U8
+  let {dep,arr} = buf
+  open idx
+  let idx = Word.trim<32>(dep, idx.value)
+  Array.get<U8, dep>(idx, arr)

--- a/base/Buffer8/set.kind
+++ b/base/Buffer8/set.kind
@@ -1,0 +1,6 @@
+Buffer8.set(idx: U32, val: U8, buf: Buffer8): Buffer8
+  let {dep,arr} = buf
+  open idx
+  let idx = Word.trim<32>(dep, idx.value)
+  def arr = Array.set<U8, dep>(idx, val, arr)
+  Buffer8.new(dep, arr)


### PR DESCRIPTION
This PR adds a `Buffer8` type, useful for serializing bytes, e.g. writing bytecode.

`Buffer8` would also need to be implemented in `FmcToJs.js` to get the full performance (should I do it?).