### PR TITLE
Improve error message for commands outside Kind/base

### DIFF
--- a/bin/js/src/main.js
+++ b/bin/js/src/main.js
@@ -28,6 +28,7 @@ function find_base_dir() {
     process.chdir(path.join(full_path, "base"));
     find_base_dir();
   } else {
+    console.log("# Kind "+require("./../package.json").version);
     console.log("Couldn't find Kind/base directory.\n");
     console.log("Go to the directory to run Kind commands or clone the repository:");
     console.log("  git clone https://github.com/uwu-tech/Kind");

--- a/bin/js/src/main.js
+++ b/bin/js/src/main.js
@@ -28,11 +28,10 @@ function find_base_dir() {
     process.chdir(path.join(full_path, "base"));
     find_base_dir();
   } else {
-    console.log("Couldn't find Kind's repository. Please, clone it with:");
-    console.log("");
+    console.log("Couldn't find Kind/base directory.\n");
+    console.log("Go to the directory to run Kind commands or clone the repository:");
     console.log("  git clone https://github.com/uwu-tech/Kind");
-    console.log("");
-    console.log("And add your files to the Kind/base directory.");
+    console.log("New files must be added inside Kind/base directory.");
     process.exit();
   }
 };


### PR DESCRIPTION
The error when running a command outside `Kind/base` directory isn't very clear:
```
Couldn't find Kind's repository. Please, clone it with:
   git clone https://github.com/uwu-tech/Kind"
And add your files to the Kind/base directory.
```

New error message:
```
Couldn't find Kind/base directory.

Go to the directory to run Kind commands or clone the repository:
  git clone https://github.com/uwu-tech/Kind
New files must be added inside Kind/base directory.
```
