### PR TITLE
correct expectation of running Main

### DIFF
--- a/bin/scm/src/main.scm
+++ b/bin/scm/src/main.scm
@@ -19,7 +19,7 @@
       ""
       "Examples:"
       ""
-      "  # Run the 'Main' term (outputs 'Hello, world'):"
+      "  # Run the 'Main' term (outputs 'oi'):"
       "  kind-scm Main --run"
       ""
       "  # Type-check all files inside the 'Nat' module:"


### PR DESCRIPTION
The current implementation of `Main.kind` outputs "oi" instead of "Hello, world"

But the help of the `kind-scm` reports that is should output "Hello, world". This pull-request changes the expectation to match the implementation.