### PR TITLE
Markdown formatting fix

### DIFF
--- a/THEOREMS.md
+++ b/THEOREMS.md
@@ -30,7 +30,7 @@ If that looks alien to you, don't worry for now, it will become clear. The
 
 ```
 Equal.refl : (A: Type) -> (x: A) -> Equal(A,x,x)
-````
+```
 
 That means `refl` receives a type (`A`), and element `x` of type `A`, and
 returns `Equal(A,x,x)`. As an example, the program below:


### PR DESCRIPTION
The extra backtick caused formatting aberration in IOS Working Copy.
I checked for other groups of 4, `rg -F ‘````’`, and found none.