### PR TITLE
Add proof that list.map keeps length

### DIFF
--- a/base/List/map/length.kind
+++ b/base/List/map/length.kind
@@ -1,0 +1,8 @@
+List.map.length<A: Type, B: Type>(
+  f: A -> B,
+  as: List<A>
+): List.length<A>(as) == List.length<B>(List.map<A, B>(f, as))
+  case as {
+    nil : refl
+    cons: apply(Nat.succ, List.map.length<A, B>(f, as.tail))
+  }!


### PR DESCRIPTION
A simple proof, but was needed for some Vector calculations