### PR TITLE
Fix infinite loop

### DIFF
--- a/src/language.rs
+++ b/src/language.rs
@@ -511,6 +511,8 @@ pub fn term_get_unbounds(book: &Book, term: &Term, rhs: bool, vars: &mut Vec<Str
       // Is unbound variable
       } else if rhs && vars.iter().find(|&x| x == name).is_none() {
         unbound.insert(name.clone());
+      } else {
+        vars.push(name.clone());
       }
     },
     Term::Let { ref name, ref expr, ref body, .. } => {

--- a/src/language.rs
+++ b/src/language.rs
@@ -509,10 +509,12 @@ pub fn term_get_unbounds(book: &Book, term: &Term, rhs: bool, vars: &mut Vec<Str
       if ('A'..='Z').contains(&name.chars().nth(0).unwrap_or(' ')) {
         unbound.insert(name.clone());
       // Is unbound variable
-      } else if rhs && vars.iter().find(|&x| x == name).is_none() {
-        unbound.insert(name.clone());
-      } else {
-        vars.push(name.clone());
+      } else if vars.iter().find(|&x| x == name).is_none() {
+        if (rhs) {
+          unbound.insert(name.clone());
+        } else {
+          vars.push(name.clone());
+        }
       }
     },
     Term::Let { ref name, ref expr, ref body, .. } => {

--- a/src/language.rs
+++ b/src/language.rs
@@ -510,7 +510,7 @@ pub fn term_get_unbounds(book: &Book, term: &Term, rhs: bool, vars: &mut Vec<Str
         unbound.insert(name.clone());
       // Is unbound variable
       } else if vars.iter().find(|&x| x == name).is_none() {
-        if (rhs) {
+        if rhs {
           unbound.insert(name.clone());
         } else {
           vars.push(name.clone());


### PR DESCRIPTION
It fixes the infinite loop by adding the variables bound by the pattern in the `vars` vector (it is not modified inside the pattern because patterns cannot have Lambdas, Pi types or Lets inside of them)