### PR TITLE
More kindelia compiler improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
+name = "getrandom"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,11 +187,12 @@ dependencies = [
 
 [[package]]
 name = "kind2"
-version = "0.2.70"
+version = "0.2.71"
 dependencies = [
  "clap",
  "highlight_error",
  "hvm",
+ "rand",
 ]
 
 [[package]]
@@ -227,6 +239,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +284,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -328,6 +376,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/src/language.rs
+++ b/src/language.rs
@@ -1625,7 +1625,8 @@ pub fn parse_entry(state: parser::State) -> parser::Answer<Box<Entry>> {
         break;
       }
     }
-    return Ok((state, Box::new(Entry { name, kdln, args, tipo, rules })));
+    let entry = Box::new(Entry { name, kdln, args, tipo, rules });
+    return Ok((state, entry));
   }
 }
 
@@ -1730,10 +1731,10 @@ pub fn load_newtype_cached(cache: &mut HashMap<String, Rc<NewType>>, name: &str)
   return Ok(cache.get(name).unwrap().clone());
 }
 
-// Compiler
-// ========
+// Type Checker Compiler
+// =====================
 
-pub fn compile_term(term: &Term, quote: bool, lhs: bool) -> String {
+pub fn to_checker_term(term: &Term, quote: bool, lhs: bool) -> String {
   fn hide(orig: &u64, lhs: bool) -> String {
     if lhs {
       "orig".to_string()
@@ -1757,27 +1758,27 @@ pub fn compile_term(term: &Term, quote: bool, lhs: bool) -> String {
       }
     }
     Term::All { orig, name, tipo, body } => {
-      format!("(Kind.Term.all {} {} {} λ{} {})", hide(orig,lhs), name_to_u64(name), compile_term(tipo, quote, lhs), name, compile_term(body, quote, lhs))
+      format!("(Kind.Term.all {} {} {} λ{} {})", hide(orig,lhs), name_to_u64(name), to_checker_term(tipo, quote, lhs), name, to_checker_term(body, quote, lhs))
     }
     Term::Lam { orig, name, body } => {
-      format!("(Kind.Term.lam {} {} λ{} {})", hide(orig,lhs), name_to_u64(name), name, compile_term(body, quote, lhs))
+      format!("(Kind.Term.lam {} {} λ{} {})", hide(orig,lhs), name_to_u64(name), name, to_checker_term(body, quote, lhs))
     }
     Term::App { orig, func, argm } => {
-      format!("({} {} {} {})", if quote { "Kind.Term.app" } else { "Kind.Term.eval_app" }, hide(orig,lhs), compile_term(func, quote, lhs), compile_term(argm, quote, lhs))
+      format!("({} {} {} {})", if quote { "Kind.Term.app" } else { "Kind.Term.eval_app" }, hide(orig,lhs), to_checker_term(func, quote, lhs), to_checker_term(argm, quote, lhs))
     }
     Term::Let { orig, name, expr, body } => {
-      format!("({} {} {} {} λ{} {})", if quote { "Kind.Term.let" } else { "Kind.Term.eval_let" }, hide(orig,lhs), name_to_u64(name), compile_term(expr, quote, lhs), name, compile_term(body, quote, lhs))
+      format!("({} {} {} {} λ{} {})", if quote { "Kind.Term.let" } else { "Kind.Term.eval_let" }, hide(orig,lhs), name_to_u64(name), to_checker_term(expr, quote, lhs), name, to_checker_term(body, quote, lhs))
     }
     Term::Ann { orig, expr, tipo } => {
-      format!("({} {} {} {})", if quote { "Kind.Term.ann" } else { "Kind.Term.eval_ann" }, hide(orig,lhs), compile_term(expr, quote, lhs), compile_term(tipo, quote, lhs))
+      format!("({} {} {} {})", if quote { "Kind.Term.ann" } else { "Kind.Term.eval_ann" }, hide(orig,lhs), to_checker_term(expr, quote, lhs), to_checker_term(tipo, quote, lhs))
     }
     Term::Sub { orig, expr, name, indx, redx } => {
-      format!("({} {} {} {} {} {})", if quote { "Kind.Term.sub" } else { "Kind.Term.eval_sub" }, hide(orig,lhs), name_to_u64(name), indx, redx, compile_term(expr, quote, lhs))
+      format!("({} {} {} {} {} {})", if quote { "Kind.Term.sub" } else { "Kind.Term.eval_sub" }, hide(orig,lhs), name_to_u64(name), indx, redx, to_checker_term(expr, quote, lhs))
     }
     Term::Ctr { orig, name, args } => {
       let mut args_strs : Vec<String> = Vec::new();
       for arg in args {
-        args_strs.push(format!(" {}", compile_term(arg, quote, lhs)));
+        args_strs.push(format!(" {}", to_checker_term(arg, quote, lhs)));
       }
       if args.len() >= 7 {
         format!("(Kind.Term.ct{} {}. {} (Kind.Term.args{}{}))", args.len(), name, hide(orig,lhs), args.len(), args_strs.join(""))
@@ -1788,7 +1789,7 @@ pub fn compile_term(term: &Term, quote: bool, lhs: bool) -> String {
     Term::Fun { orig, name, args } => {
       let mut args_strs : Vec<String> = Vec::new();
       for arg in args {
-        args_strs.push(format!(" {}", compile_term(arg, quote, lhs)));
+        args_strs.push(format!(" {}", to_checker_term(arg, quote, lhs)));
       }
       if quote {
         if args.len() >= 7 {
@@ -1811,7 +1812,7 @@ pub fn compile_term(term: &Term, quote: bool, lhs: bool) -> String {
     }
     Term::Op2 { orig, oper, val0, val1 } => {
       // TODO: Add operator
-      format!("({} {} {} {} {})", if quote { "Kind.Term.op2" } else { "Kind.Term.eval_op" }, hide(orig,lhs), compile_oper(oper), compile_term(val0, quote, lhs), compile_term(val1, quote, lhs))
+      format!("({} {} {} {} {})", if quote { "Kind.Term.op2" } else { "Kind.Term.eval_op" }, hide(orig,lhs), to_checker_oper(oper), to_checker_term(val0, quote, lhs), to_checker_term(val1, quote, lhs))
     }
     Term::Hol { orig, numb } => {
       format!("(Kind.Term.hol {} {})", orig, numb)
@@ -1822,7 +1823,7 @@ pub fn compile_term(term: &Term, quote: bool, lhs: bool) -> String {
   }
 }
 
-pub fn compile_oper(oper: &Oper) -> String {
+pub fn to_checker_oper(oper: &Oper) -> String {
   match oper {
     Oper::Add => "Kind.Operator.add".to_string(),
     Oper::Sub => "Kind.Operator.sub".to_string(),
@@ -1843,17 +1844,17 @@ pub fn compile_oper(oper: &Oper) -> String {
   }
 }
 
-pub fn compile_entry(entry: &Entry) -> String {
-  fn compile_type(args: &Vec<Box<Argument>>, tipo: &Box<Term>, index: usize) -> String {
+pub fn to_checker_entry(entry: &Entry) -> String {
+  fn to_checker_type(args: &Vec<Box<Argument>>, tipo: &Box<Term>, index: usize) -> String {
     if index < args.len() {
       let arg = &args[index];
-      format!("(Kind.Term.all {} {} {} λ{} {})", 0, name_to_u64(&arg.name), compile_term(&arg.tipo, true, false), arg.name, compile_type(args, tipo, index + 1))
+      format!("(Kind.Term.all {} {} {} λ{} {})", 0, name_to_u64(&arg.name), to_checker_term(&arg.tipo, true, false), arg.name, to_checker_type(args, tipo, index + 1))
     } else {
-      compile_term(tipo, true, false)
+      to_checker_term(tipo, true, false)
     }
   }
 
-  fn compile_rule_end(name: &str, size: u64) -> String {
+  fn to_checker_rule_end(name: &str, size: u64) -> String {
     let mut vars = vec![];
     for idx in 0 .. size {
       vars.push(format!(" x{}", idx));
@@ -1871,13 +1872,13 @@ pub fn compile_entry(entry: &Entry) -> String {
     return text;
   }
 
-  fn compile_rule(rule: &Rule) -> String {
+  fn to_checker_rule(rule: &Rule) -> String {
     let mut pats = vec![];
     for pat in &rule.pats {
-      pats.push(format!(" {}", compile_term(pat, false, true)));
+      pats.push(format!(" {}", to_checker_term(pat, false, true)));
     }
-    let body_rhs = compile_term(&rule.body, true, false);
-    let rule_rhs = compile_term(&rule.body, false, false);
+    let body_rhs = to_checker_term(&rule.body, true, false);
+    let rule_rhs = to_checker_term(&rule.body, false, false);
     let mut text = String::new();
     text.push_str(&format!("(Q${} orig{}) = {}\n", rule.name, pats.join(""), body_rhs));
     if rule.name == "HVM.log" {
@@ -1899,19 +1900,19 @@ pub fn compile_entry(entry: &Entry) -> String {
     return text;
   }
 
-  fn compile_rule_chk(rule: &Rule, index: usize, vars: &mut u64, args: &mut Vec<String>) -> String {
+  fn to_checker_rule_chk(rule: &Rule, index: usize, vars: &mut u64, args: &mut Vec<String>) -> String {
     if index < rule.pats.len() {
-      let (inp_patt_str, var_patt_str) = compile_patt_chk(&rule.pats[index], vars);
+      let (inp_patt_str, var_patt_str) = to_checker_patt_chk(&rule.pats[index], vars);
       args.push(var_patt_str);
       let head = inp_patt_str;
-      let tail = compile_rule_chk(rule, index + 1, vars, args);
+      let tail = to_checker_rule_chk(rule, index + 1, vars, args);
       return format!("(Kind.Rule.lhs {} {})", head, tail);
     } else {
       return format!("(Kind.Rule.rhs (QT{} {}. 0{}))", index, rule.name, args.iter().map(|x| format!(" {}", x)).collect::<Vec<String>>().join(""));
     }
   }
 
-  fn compile_patt_chk(patt: &Term, vars: &mut u64) -> (String, String) {
+  fn to_checker_patt_chk(patt: &Term, vars: &mut u64) -> (String, String) {
     // FIXME: remove redundancy
     match patt {
       Term::Var { orig, name } => {
@@ -1924,7 +1925,7 @@ pub fn compile_entry(entry: &Entry) -> String {
         let mut inp_args_str = String::new();
         let mut var_args_str = String::new();
         for arg in args {
-          let (inp_arg_str, var_arg_str) = compile_patt_chk(arg, vars);
+          let (inp_arg_str, var_arg_str) = to_checker_patt_chk(arg, vars);
           inp_args_str.push_str(&format!(" {}", inp_arg_str));
           var_args_str.push_str(&format!(" {}", var_arg_str));
         }
@@ -1953,7 +1954,7 @@ pub fn compile_entry(entry: &Entry) -> String {
   let mut result = String::new();
   result.push_str(&format!("(NameOf {}.) = \"{}\"\n", entry.name, entry.name));
   result.push_str(&format!("(HashOf {}.) = %{}\n", entry.name, entry.name));
-  result.push_str(&format!("(TypeOf {}.) = {}\n", entry.name, compile_type(&entry.args, &entry.tipo, 0)));
+  result.push_str(&format!("(TypeOf {}.) = {}\n", entry.name, to_checker_type(&entry.args, &entry.tipo, 0)));
 
   let base_vars = (0 .. entry.args.len()).map(|x| format!(" x{}", x)).collect::<Vec<String>>().join("");
 
@@ -1966,20 +1967,20 @@ pub fn compile_entry(entry: &Entry) -> String {
   result.push_str(&format!("(QT{} {}. orig{}) = (Q${} orig{})\n", entry.args.len(), entry.name, base_vars, entry.name, base_vars));
   
   for rule in &entry.rules {
-    result.push_str(&compile_rule(&rule));
+    result.push_str(&to_checker_rule(&rule));
   }
   if entry.rules.len() > 0 {
-    result.push_str(&compile_rule_end(&entry.name, entry.rules[0].pats.len() as u64));
+    result.push_str(&to_checker_rule_end(&entry.name, entry.rules[0].pats.len() as u64));
   }
   result.push_str(&format!("(RuleOf {}.) =", entry.name));
   for rule in &entry.rules {
-    result.push_str(&format!(" (List.cons {}", compile_rule_chk(&rule, 0, &mut 0, &mut vec![]))); 
+    result.push_str(&format!(" (List.cons {}", to_checker_rule_chk(&rule, 0, &mut 0, &mut vec![]))); 
   }
   result.push_str(&format!(" List.nil{}", ")".repeat(entry.rules.len())));
   return result;
 }
 
-pub fn compile_book(book: &Book) -> String {
+pub fn to_checker_book(book: &Book) -> String {
   let mut result = String::new();
   result.push_str(&format!("// NOTE: functions with names starting with 'F$' are evaluated differently by the\n"));
   result.push_str(&format!("// HVM, as a specific optimization targetting Kind2. See 'HOAS_OPT' on HVM's code.\n\n"));
@@ -1995,7 +1996,7 @@ pub fn compile_book(book: &Book) -> String {
     result.push_str(&format!("\n// {}", name));
     result.push_str(&format!("\n// {}\n", "-".repeat(name.len())));
     result.push_str(&format!("\n"));
-    result.push_str(&compile_entry(&entry));
+    result.push_str(&to_checker_entry(&entry));
     result.push_str(&format!("\n"));
   }
   //result.push_str(&format!("\n// Default Cases"));
@@ -2244,49 +2245,374 @@ pub fn count_implicits(entry: &Entry) -> (usize, usize) {
   (hiddens, eraseds)
 }
 
+
+// Kindelia Compiler
+// =================
+
 // Returns true if a ctor's argument is erased
 #[derive(Clone, Debug)]
-pub enum Comp {
+pub enum CompTerm {
   Var { name: String },
-  Lam { name: String, body: Box<Comp> },
-  App { func: Box<Comp>, argm: Box<Comp> },
-  Dup { nam0: String, nam1: String, expr: Box<Comp>, body: Box<Comp> },
-  Let { name: String, expr: Box<Comp>, body: Box<Comp> },
-  Ctr { name: String, args: Vec<Box<Comp>> },
-  Fun { name: String, args: Vec<Box<Comp>> },
+  Lam { name: String, body: Box<CompTerm> },
+  App { func: Box<CompTerm>, argm: Box<CompTerm> },
+  Dup { nam0: String, nam1: String, expr: Box<CompTerm>, body: Box<CompTerm> },
+  Let { name: String, expr: Box<CompTerm>, body: Box<CompTerm> },
+  Ctr { name: String, args: Vec<Box<CompTerm>> },
+  Fun { name: String, args: Vec<Box<CompTerm>> },
   Num { numb: u64 },
-  Op2 { oper: Oper, val0: Box<Comp>, val1: Box<Comp> },
+  Op2 { oper: Oper, val0: Box<CompTerm>, val1: Box<CompTerm> },
   Nil
 }
 
+#[derive(Clone, Debug)]
+pub struct CompRule {
+  pub name: String,
+  pub pats: Vec<Box<CompTerm>>,
+  pub body: Box<CompTerm>,
+}
+
+#[derive(Clone, Debug)]
+pub struct CompEntry {
+  pub name : String,
+  pub kdln : Option<String>,
+  pub args : Vec<String>,
+  pub rules: Vec<CompRule>,
+  pub orig : bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct CompBook {
+  pub names: Vec<String>,
+  pub entrs: HashMap<String, CompEntry>,
+}
+
+// TODO: Add possible fail result to the compilation
+pub fn compile_book(book: &Book) -> CompBook {
+  let mut comp_book = CompBook { names: Vec::new(), entrs: HashMap::new() };
+  for name in &book.names {
+    let entry = book.entrs.get(name).unwrap();
+    // Skip over useless entries
+    // TODO: This doesn't cover all cases. We need something like `erase` but for a Book.
+    //       Also maybe there are functions of type Type that should be compiled?
+    if let Term::Typ {orig: _} = &*entry.tipo {
+      continue;
+    } else {
+      let entrs = compile_entry(book, entry);
+      for entry in entrs {
+        comp_book.names.push(entry.name.clone());
+        comp_book.entrs.insert(entry.name.clone(), entry);
+      }
+    }
+  }
+  comp_book
+}
+
+// Can become multiple entries after flatenning
+pub fn compile_entry(book: &Book, entry: &Entry) -> Vec<CompEntry> {
+  fn compile_rule(book: &Book, entry: &Entry, rule: &Rule) -> CompRule {
+    let name = rule.name.clone();
+    let mut pats = Vec::new();
+    for (arg, pat) in entry.args.iter().zip(rule.pats.iter()) {
+      if !arg.eras {
+        let pat = erase(book, pat);
+        // TODO: Check if the pattern has some invalid term (anything other than num, ctr or var)
+        pats.push(pat);
+      }
+    }
+    let body = erase(book, &rule.body);
+    CompRule {name, pats, body}
+  }
+
+  let entry = CompEntry {
+    name : entry.name.clone(),
+    kdln : entry.kdln.clone(),
+    args : entry.args.iter().filter(|x| !x.eras).map(|x| x.name.clone()).collect(),
+    rules: entry.rules.iter().map(|rule| compile_rule(book, entry, rule)).collect(),
+    orig : true,
+  };
+  let mut new_entrs = flatten(entry);
+  for entry in &mut new_entrs {
+    for rule in &mut entry.rules {
+      linearize_rule(rule);
+    }
+  }
+  new_entrs
+}
+
+// Splits an entry with rules with nested cases into multiple entries with flattened rules.
+pub fn flatten(entry: CompEntry) -> Vec<CompEntry> {
+  fn post_inc(n: &mut u64) -> u64 {
+    let old_n = *n;
+    *n += 1;
+    old_n
+  }
+
+  fn must_split(rule: &CompRule) -> bool {
+    for pat in &rule.pats {
+      if let CompTerm::Ctr { args, .. } = &**pat {
+        for arg in args {
+          if matches!(&**arg, CompTerm::Ctr { .. } | CompTerm::Num { .. }) {
+            return true;
+          }
+        }
+      }
+    }
+    false
+  }
+
+  // return true on the first if both rules always match together
+  fn matches_together(a: &CompRule, b: &CompRule) -> (bool, bool) {
+    let mut same_shape = true;
+    for (a_pat, b_pat) in a.pats.iter().zip(&b.pats) {
+      match (&**a_pat, &**b_pat) {
+        (CompTerm::Ctr { name: a_name, .. }, CompTerm::Ctr { name: b_name, .. }) => {
+          if a_name != b_name {
+            return (false, false);
+          }
+        },
+        (CompTerm::Num { numb: a_numb }, CompTerm::Num { numb: b_numb }) => {
+          if a_numb != b_numb {
+            return (false, false);
+          }
+        },
+        (CompTerm::Ctr { .. }, CompTerm::Num { .. }) => { return (false, false); },
+        (CompTerm::Num { .. }, CompTerm::Ctr { .. }) => { return (false, false); },
+        (CompTerm::Ctr { .. }, CompTerm::Var { .. }) => { same_shape = false; },
+        (CompTerm::Num { .. }, CompTerm::Var { .. }) => { same_shape = false; },
+        // TODO: Shouldn't this also include (var{}, _) ?
+        _ => {},
+      }
+    }
+    (true, same_shape)
+  }
+
+  let mut name_count = 0;
+
+  let mut skip           : HashSet<usize> = HashSet::new();
+  let mut new_entries    : Vec<CompEntry> = Vec::new();
+  let mut old_entry_rules: Vec<CompRule>  = Vec::new();
+  let old_entry_args     : Vec<String>    = entry.args;
+  for i in 0..entry.rules.len() {
+    if !skip.contains(&i) {
+      let rule = &entry.rules[i];
+      if must_split(rule) {
+        // Each rule that must be split creates a new entry that inspects one layer of Ctrs
+        // The old rule is rewritten to be flat and call the new entry
+        let n = post_inc(&mut name_count);
+        let new_entry_name = format!("{}{}_", entry.name, n);
+        let new_entry_kdln = entry.kdln.clone().and_then(|kdln| Some(format!("{}{}_", kdln, n)));
+        let mut new_entry_rules: Vec<CompRule> = Vec::new();
+        // Rewrite the old rule to be flat and point to the new entry
+        let mut old_rule_pats     : Vec<Box<CompTerm>> = Vec::new();
+        let mut old_rule_body_args: Vec<Box<CompTerm>> = Vec::new();
+        let mut var_count = 0;
+        for pat in &rule.pats {
+          match &**pat {
+            CompTerm::Ctr { name: pat_name, args: pat_args } => {
+              let mut new_pat_args = Vec::new();
+              for field in pat_args {
+                match &**field {
+                  CompTerm::Ctr { .. } => {
+                    let var_name = format!(".{}", post_inc(&mut var_count));
+                    new_pat_args.push(Box::new(CompTerm::Var { name: var_name.clone() }));
+                    old_rule_body_args.push(Box::new(CompTerm::Var { name: var_name.clone() }));
+                  }
+                  CompTerm::Num { .. } => {
+                    let var_name = format!(".{}", post_inc(&mut var_count));
+                    new_pat_args.push(Box::new(CompTerm::Var { name: var_name.clone() }));
+                    old_rule_body_args.push(Box::new(CompTerm::Var { name: var_name.clone() }));
+                  }
+                  CompTerm::Var { name } => {
+                    new_pat_args.push(field.clone());
+                    old_rule_body_args.push(field.clone());
+                  }
+                  _ => {
+                    panic!("?");
+                  }
+                }
+              }
+              old_rule_pats.push(Box::new(CompTerm::Ctr { name: pat_name.clone(), args: new_pat_args }));
+            }
+            CompTerm::Var { name } => {
+              old_rule_pats.push(Box::new(*pat.clone()));
+              old_rule_body_args.push(Box::new(CompTerm::Var { name: name.clone() }));
+            }
+            // TODO: Shouldn't it also check for Num?
+            _ => {}
+          }
+        }
+        let old_rule_body = Box::new(CompTerm::Fun { name: new_entry_name.clone(), args: old_rule_body_args });
+        let old_rule = CompRule {name: entry.name.clone(), pats: old_rule_pats, body: old_rule_body };
+        old_entry_rules.push(old_rule);
+        //(Foo Tic (Bar a b) (Haz c d)) = A
+        //(Foo Tic x         y)         = B
+        //---------------------------------
+        //(Foo Tic (Bar a b) (Haz c d)) = B[x <- (Bar a b), y <- (Haz c d)]
+        //
+        //(Foo.0 a b c d) = ...
+
+        // Check the rules to see if there's any that will be covered by the new entry, including the rule itself.
+        // Skips previously checked rules to avoid duplication.
+        // For each unique matching rule, creates a new flattening rule for the entry.
+        // Ex: (Fun (Ctr1 (Ctr2))) and (Fun (Ctr1 (Ctr3))) will both flatten to (Fun (Ctr1 .0)) and can be merged
+        for (j, other) in entry.rules.iter().enumerate().skip(i) {
+          let (compatible, same_shape) = matches_together(&rule, &other);
+          if compatible {
+            // (Foo a     (B x P) (C y0 y1)) = F
+            // (Foo (A k) (B x Q) y        ) = G
+            // -----------------------------
+            // (Foo a (B x u) (C y0 y1)) = (Foo.0 a x u y0 y1)
+            //   (Foo.0 a     x P y0 y1) = F
+            //   (Foo.0 (A k) x Q f0 f1) = G [y <- (C f0 f1)] // f0 and f1 are fresh
+
+            // Skip identical rules
+            if same_shape {
+              skip.insert(j);
+            }
+            let mut new_rule_pats = Vec::new();
+            let mut new_rule_body = other.body.clone();
+            for (rule_pat, other_pat) in rule.pats.iter().zip(&other.pats) {
+              match (&**rule_pat, &**other_pat) {
+                (CompTerm::Ctr { name: _, args: _ }, CompTerm::Ctr { name: _, args: other_pat_args }) => {
+                  for other_field in other_pat_args {
+                    new_rule_pats.push(other_field.clone());
+                  }
+                },
+                (CompTerm::Ctr { name: rule_pat_name, args: rule_pat_args }, CompTerm::Var { name: other_pat_name }) => {
+                  let mut new_ctr_args = vec![];
+                      for _ in 0 .. rule_pat_args.len() {
+                        let new_arg = CompTerm::Var { name: format!(".{}", post_inc(&mut var_count)) };
+                        new_ctr_args.push(Box::new(new_arg.clone()));
+                        new_rule_pats.push(Box::new(new_arg));
+                      }
+                      let new_ctr = CompTerm::Ctr { name: rule_pat_name.clone(), args: new_ctr_args };
+                      subst(&mut new_rule_body, other_pat_name, &new_ctr);
+                },
+                (CompTerm::Var { .. }, _) => {
+                  new_rule_pats.push(other_pat.clone());
+                },
+                (CompTerm::Num { numb: rule_pat_numb }, CompTerm::Num { numb: other_pat_numb }) => {
+                  if rule_pat_numb == other_pat_numb {
+                    new_rule_pats.push(Box::new(*other_pat.clone()));
+                  } else {
+                    panic!("Internal error. Please report."); // not possible since it matches
+                  }
+                },
+                (CompTerm::Num { numb: _ }, CompTerm::Var { name: other_pat_name }) => {
+                  subst(&mut new_rule_body, other_pat_name, &rule_pat);
+                },
+                _ => {
+                  panic!("Internal error. Please report."); // not possible since it matches
+                },
+              }
+            }
+            let new_rule = CompRule { name: new_entry_name.clone(), pats: new_rule_pats, body: new_rule_body };
+            new_entry_rules.push(new_rule);
+          }
+        }
+        assert!(new_entry_rules.len() > 0);  // There's at least one rule, since rules always match with themselves
+        let new_entry_args = (0..new_entry_rules[0].pats.len()).map(|n| format!("x{}", n)).collect();
+        let new_entry = CompEntry {
+          name : new_entry_name,
+          kdln : new_entry_kdln,
+          args : new_entry_args,
+          rules: new_entry_rules,
+          orig : false
+        };
+        let new_split_entries = flatten(new_entry);
+        new_entries.extend(new_split_entries);
+      } else {
+        old_entry_rules.push(entry.rules[i].clone());
+      }
+    }
+  }
+  let old_entry = CompEntry {
+    name: entry.name,
+    kdln: entry.kdln,
+    args: old_entry_args,
+    rules: old_entry_rules,
+    orig: entry.orig
+  };
+  new_entries.push(old_entry);
+  new_entries
+}
+
+// Substitute all instances of a variable in a term with another term
+pub fn subst(term: &mut CompTerm, sub_name: &str, value: &CompTerm) {
+  match term {
+    CompTerm::Var { name } => {
+      if sub_name == name {
+        *term = value.clone();
+      }
+    }
+    CompTerm::Dup { nam0, nam1, expr, body } => {
+      subst(&mut *expr, sub_name, value);
+      if nam0 != sub_name && nam1 != sub_name {
+        subst(&mut *body, sub_name, value);
+      }
+    }
+    CompTerm::Let { name, expr, body } => {
+      subst(&mut *expr, sub_name, value);
+      if name != sub_name {
+        subst(&mut *body, sub_name, value);
+      }
+    }
+    CompTerm::Lam { name, body } => {
+      if name != sub_name {
+        subst(&mut *body, sub_name, value);
+      }
+    }
+    CompTerm::App { func, argm } => {
+      subst(&mut *func, sub_name, value);
+      subst(&mut *argm, sub_name, value);
+    }
+    CompTerm::Ctr { args, .. } => {
+      for arg in args {
+        subst(&mut *arg, sub_name, value);
+      }
+    }
+    CompTerm::Fun { args, .. } => {
+      for arg in args {
+        subst(&mut *arg, sub_name, value);
+      }
+    }
+    CompTerm::Num { .. } => {}
+    CompTerm::Op2 { val0, val1, .. } => {
+      subst(&mut *val0, sub_name, value);
+      subst(&mut *val1, sub_name, value);
+    }
+    CompTerm::Nil => {}
+  }
+}
+
 // Removes proof-irrelevant parts of the term
-pub fn erase(book: &Book, term: &Term) -> Box<Comp> {
+pub fn erase(book: &Book, term: &Term) -> Box<CompTerm> {
   match term {
     Term::Typ { .. } => {
-      return Box::new(Comp::Nil);
+      return Box::new(CompTerm::Nil);
     }
     Term::Var { orig: _, name } => {
       let name = name.clone();
-      return Box::new(Comp::Var { name });
+      return Box::new(CompTerm::Var { name });
     }
     Term::Lam { orig: _, name, body } => {
       let name = name.clone();
       let body = erase(book, body);
-      return Box::new(Comp::Lam { name, body });
+      return Box::new(CompTerm::Lam { name, body });
     }
     Term::App { orig: _, func, argm } => {
       let func = erase(book, func);
       let argm = erase(book, argm);
-      return Box::new(Comp::App { func, argm });
+      return Box::new(CompTerm::App { func, argm });
     }
     Term::All { orig: _, name, tipo, body } => {
-      return Box::new(Comp::Nil);
+      return Box::new(CompTerm::Nil);
     }
     Term::Let { orig: _, name, expr, body } => {
       let name = name.clone();
       let expr = erase(book, expr);
       let body = erase(book, body);
-      return Box::new(Comp::Let { name, expr, body });
+      return Box::new(CompTerm::Let { name, expr, body });
     }
     Term::Ann { orig: _, expr, tipo: _ } => {
       return erase(book, expr);
@@ -2303,7 +2629,7 @@ pub fn erase(book: &Book, term: &Term) -> Box<Comp> {
           args.push(erase(book, arg));
         }
       }
-      return Box::new(Comp::Ctr { name, args });
+      return Box::new(CompTerm::Ctr { name, args });
     }
     Term::Fun { orig: _, name, args: term_args } => {
       let name = name.clone();
@@ -2314,215 +2640,264 @@ pub fn erase(book: &Book, term: &Term) -> Box<Comp> {
           args.push(erase(book, arg));
         }
       }
-      return Box::new(Comp::Fun { name, args });
+      return Box::new(CompTerm::Fun { name, args });
     }
     Term::Hlp { orig: _ } => {
-      return Box::new(Comp::Nil);
+      return Box::new(CompTerm::Nil);
     }
     Term::U60 { orig: _ } => {
-      return Box::new(Comp::Nil);
+      return Box::new(CompTerm::Nil);
     }
     Term::Num { orig: _, numb } => {
       let numb = *numb;
-      return Box::new(Comp::Num { numb });
+      return Box::new(CompTerm::Num { numb });
     }
     Term::Op2 { orig: _, oper, val0, val1 } => {
       let oper = oper.clone();
       let val0 = erase(book, val0);
       let val1 = erase(book, val1);
-      return Box::new(Comp::Op2 { oper, val0, val1 });
+      return Box::new(CompTerm::Op2 { oper, val0, val1 });
     }
     Term::Hol { orig: _, numb } => {
-      return Box::new(Comp::Nil);
+      return Box::new(CompTerm::Nil);
     }
     Term::Mat { .. } => {
-      return Box::new(Comp::Nil);
+      return Box::new(CompTerm::Nil);
     }
   }
 }
 
 // Counts usages of a name in an erased term
-pub fn count_uses(term: &Comp, count_name: &str) -> usize {
+pub fn count_uses(term: &CompTerm, count_name: &str) -> usize {
   match term {
-    Comp::Var { name } => {
+    CompTerm::Var { name } => {
       if name == count_name { 1 } else { 0 }
     }
-    Comp::Lam { name, body } => {
+    CompTerm::Lam { name, body } => {
       if name == count_name {
         0
       } else {
         count_uses(body, count_name)
       }
     }
-    Comp::App { func, argm } => {
+    CompTerm::App { func, argm } => {
       count_uses( func, count_name) + count_uses(argm, count_name)
     }
-    Comp::Dup { nam0, nam1, expr, body } => {
+    CompTerm::Dup { nam0, nam1, expr, body } => {
       count_uses(expr, count_name) + (if nam0 == count_name || nam1 == count_name { 0 } else { count_uses(body, count_name) })
     }
-    Comp::Let { name, expr, body } => {
+    CompTerm::Let { name, expr, body } => {
       count_uses(expr, count_name) + (if name == count_name { 0 } else { count_uses(body, count_name) })
     }
-    Comp::Ctr { name, args } => {
+    CompTerm::Ctr { name, args } => {
       let mut sum = 0;
       for arg in args {
         sum += count_uses(arg, count_name);
       }
       return sum;
     }
-    Comp::Fun { name, args } => {
+    CompTerm::Fun { name, args } => {
       let mut sum = 0;
       for arg in args {
         sum += count_uses(arg, count_name);
       }
       return sum;
     }
-    Comp::Op2 { oper: _, val0, val1 } => {
+    CompTerm::Op2 { oper: _, val0, val1 } => {
       count_uses(val0, count_name) + count_uses(val1, count_name)
     }
-    Comp::Num { .. } => {
+    CompTerm::Num { .. } => {
       0
     }
-    Comp::Nil => {
+    CompTerm::Nil => {
       0
     }
   }
 }
 
 // Renames a target variable using the fresh names in a vector
-pub fn rename_clones(term: &mut Comp, target: &str, names: &mut Vec<String>) {
+pub fn rename_clones(term: &mut CompTerm, target: &str, names: &mut Vec<String>) {
   match term {
-    Comp::Var { name } => {
+    CompTerm::Var { name } => {
       if name == target {
         *name = names.pop().unwrap();
       }
     }
-    Comp::Lam { name, body } => {
+    CompTerm::Lam { name, body } => {
       if name != target {
         rename_clones(body, target, names);
       }
     }
-    Comp::App { func, argm } => {
+    CompTerm::App { func, argm } => {
       rename_clones(func, target, names);
       rename_clones(argm, target, names);
     }
-    Comp::Dup { nam0, nam1, expr, body } => {
+    CompTerm::Dup { nam0, nam1, expr, body } => {
       rename_clones(expr, target, names);
       if nam0 != target && nam1 != target {
         rename_clones(body, target, names);
       }
     }
-    Comp::Let { name, expr, body } => {
+    CompTerm::Let { name, expr, body } => {
       rename_clones(expr, target, names);
       if name != target {
         rename_clones(body, target, names);
       }
     }
-    Comp::Ctr { name, args } => {
+    CompTerm::Ctr { name, args } => {
       for arg in args {
         rename_clones(arg, target, names);
       }
     }
-    Comp::Fun { name, args } => {
+    CompTerm::Fun { name, args } => {
       for arg in args {
         rename_clones(arg, target, names);
       }
     }
-    Comp::Op2 { oper: _, val0, val1 } => {
+    CompTerm::Op2 { oper: _, val0, val1 } => {
       rename_clones(val0, target, names);
       rename_clones(val1, target, names);
     }
-    Comp::Num { .. } => {}
-    Comp::Nil => {}
+    CompTerm::Num { .. } => {}
+    CompTerm::Nil => {}
   }
 }
 
-// linearize_name (Foo x x x x) 'x' 0
-// ----------------------------------------------------------------
-// dup x0 x1 = x; dup x2 x3 = x0; dup x4 x5 = x1; (Foo x2 x3 x4 x5)
-// Returns the number of times the variable was used in the body.
-pub fn linearize_name(body: &mut Comp, name: &mut String, fresh: &mut u64) -> usize {
-  fn fresh_name(fresh: &mut u64) -> String {
-    let name = format!("_{}", fresh);
-    *fresh += 1;
-    return name;
-  }
-  let uses = count_uses(&body, name);
-  if uses > 1 {
-    let mut names = vec![];
-    for _ in 0 .. (uses - 1) * 2 {
-      names.push(fresh_name(fresh));
-    }
-    //println!("-> uses is {}, names is {:?}", uses, names);
-    let mut renames = vec![];
-    for rename in names[names.len() - uses ..].iter().rev() {
-      renames.push(rename.clone());
-    }
-    rename_clones(body, name, &mut renames);
-    for i in (0 .. uses - 1).rev() {
-      let nam0 = names[i * 2 + 0].clone();
-      let nam1 = names[i * 2 + 1].clone();
-      let expr = Box::new(Comp::Var {
-        name: if i == 0 {
-          name.to_string()
-        } else {
-          names[i - 1].clone()
+pub fn linearize_rule(rule: &mut CompRule) {
+  // Returns left-hand side variables
+  fn collect_lhs_vars<'a>(term: &'a mut CompTerm, vars: &mut HashMap<String, &'a mut CompTerm>) {
+    match term {
+      CompTerm::Var { name } => {
+        vars.insert(name.clone(), term);
+      }
+      CompTerm::App { func, argm } => {
+        collect_lhs_vars(func, vars);
+        collect_lhs_vars(argm, vars);
+      }
+      CompTerm::Ctr { args, .. } => {
+        for arg in args {
+          collect_lhs_vars(arg, vars);
         }
-      });
-      let new_body = Comp::Dup { nam0, nam1, expr, body: Box::new(Comp::Nil) };
-      let old_body = std::mem::replace(body, new_body);
-      if let Comp::Dup { ref mut body, .. } = body {
-        let _ = std::mem::replace(body, Box::new(old_body));
       }
+      CompTerm::Num { .. } => {}
+      _ => { panic!("Invalid left-hand side."); }
     }
-  } else if uses == 0 {
-    *name = String::from("~")
   }
-  return uses;
-}
 
-// Linearies an erased term, replacing cloned variables by dups
-pub fn linearize(term: &mut Comp, fresh: &mut u64) {
-  //println!("Linearizing: {:?}", term);
-  match term {
-    Comp::Var { name } => {}
-    Comp::Lam { ref mut name, body } => {
-      linearize(body, fresh);
-      linearize_name(body, name, fresh);
+  // linearize_name (Foo x x x x) 'x' 0
+  // ----------------------------------------------------------------
+  // dup x0 x1 = x; dup x2 x3 = x0; dup x4 x5 = x1; (Foo x2 x3 x4 x5)
+  // Returns the number of times the variable was used in the body.
+  pub fn linearize_name(body: &mut CompTerm, name: &mut String, fresh: &mut u64) -> usize {
+    fn fresh_name(fresh: &mut u64) -> String {
+      let name = format!("_{}", fresh);
+      *fresh += 1;
+      return name;
     }
-    Comp::App { func, argm } => {
-      linearize(func, fresh);
-      linearize(argm, fresh);
-    }
-    Comp::Let { ref mut name, expr, body } => {
-      linearize(expr, fresh);
-      linearize(body, fresh);
-      linearize_name(body, name, fresh);
-    }
-    Comp::Ctr { name, args } => {
-      for arg in args {
-        linearize(arg, fresh);
+    let uses = count_uses(&body, name);
+    if uses > 1 {
+      let mut names = vec![];
+      for _ in 0 .. (uses - 1) * 2 {
+        names.push(fresh_name(fresh));
       }
-    }
-    Comp::Fun { name, args } => {
-      for arg in args {
-        linearize(arg, fresh);
+      //println!("-> uses is {}, names is {:?}", uses, names);
+      let mut renames = vec![];
+      for rename in names[names.len() - uses ..].iter().rev() {
+        renames.push(rename.clone());
       }
+      rename_clones(body, name, &mut renames);
+      for i in (0 .. uses - 1).rev() {
+        let nam0 = names[i * 2 + 0].clone();
+        let nam1 = names[i * 2 + 1].clone();
+        let expr = Box::new(CompTerm::Var {
+          name: if i == 0 {
+            name.to_string()
+          } else {
+            names[i - 1].clone()
+          }
+        });
+        let new_body = CompTerm::Dup { nam0, nam1, expr, body: Box::new(CompTerm::Nil) };
+        let old_body = std::mem::replace(body, new_body);
+        if let CompTerm::Dup { ref mut body, .. } = body {
+          let _ = std::mem::replace(body, Box::new(old_body));
+        }
+      }
+    } else if uses == 0 {
+      *name = String::from("~")
     }
-    Comp::Op2 { oper: _, val0, val1 } => {
-      linearize(val0, fresh);
-      linearize(val1, fresh);
-    }
-    Comp::Dup { ref mut nam0, ref mut nam1, expr, body, .. } => {
-      // should be unreachable under normal usage, but I made it anyway
-      linearize(expr, fresh);
-      linearize(body, fresh);
-      linearize_name(body, nam0, fresh);
-      linearize_name(body, nam1, fresh);
-    }
-    Comp::Num { .. } => {}
-    Comp::Nil => {}
+    return uses;
   }
+
+  // Linearies an erased term, replacing cloned variables by dups
+  pub fn linearize_term(term: &mut CompTerm, fresh: &mut u64) {
+    //println!("Linearizing: {:?}", term);
+    match term {
+      CompTerm::Var { name } => {}
+      CompTerm::Lam { ref mut name, body } => {
+        linearize_term(body, fresh);
+        linearize_name(body, name, fresh);
+      }
+      CompTerm::App { func, argm } => {
+        linearize_term(func, fresh);
+        linearize_term(argm, fresh);
+      }
+      CompTerm::Let { ref mut name, expr, body } => {
+        linearize_term(expr, fresh);
+        linearize_term(body, fresh);
+        linearize_name(body, name, fresh);
+      }
+      CompTerm::Ctr { name, args } => {
+        for arg in args {
+          linearize_term(arg, fresh);
+        }
+      }
+      CompTerm::Fun { name, args } => {
+        for arg in args {
+          linearize_term(arg, fresh);
+        }
+      }
+      CompTerm::Op2 { oper: _, val0, val1 } => {
+        linearize_term(val0, fresh);
+        linearize_term(val1, fresh);
+      }
+      CompTerm::Dup { ref mut nam0, ref mut nam1, expr, body, .. } => {
+        // should be unreachable under normal usage, but I made it anyway
+        linearize_term(expr, fresh);
+        linearize_term(body, fresh);
+        linearize_name(body, nam0, fresh);
+        linearize_name(body, nam1, fresh);
+      }
+      CompTerm::Num { .. } => {}
+      CompTerm::Nil => {}
+    }
+  }
+
+  let mut vars = HashMap::new();  // rule pattern vars
+  for pat in &mut rule.pats {
+    collect_lhs_vars(&mut **pat, &mut vars);
+  }
+  let mut fresh = 0;
+  for (mut name, var) in vars.drain() {
+    let uses = linearize_name(&mut rule.body, &mut name, &mut fresh); // linearizes rule pattern vars
+    // The &mut here doesn't do anything because
+    // we're dropping var immediately afterwards.
+    // To linearize rule variables, we'll have to replace all LHS occurrences by ~
+    // if the amount of uses is zero
+    if uses == 0 {
+      if let CompTerm::Var { name } = var {
+        *name = String::from("~");
+      }
+    }
+    // The reason why we don't simply pass a real mutable reference to our variable
+    // (instead of a mutable reference of a clone) 
+    // to linearize_name is because since `var` is in `body`, we would 
+    // be borrowing `var` mutably twice, which is not allowed.
+    
+    // The reason why linearize_name takes in a mutable reference is
+    // to replace unused vars by ~. This is useful, for example, in 
+    // lambdas. (@x0 #0 should be linearized to @~ #0)
+  }
+  linearize_term(&mut rule.body, &mut fresh); // linearizes internal bound vars
 }
 
 // Derivers

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,8 +161,9 @@ fn cmd_show(path: &str) -> Result<(), String> {
 // Compiles a file to Kindelia (.kdl)
 fn cmd_to_kdl(path: &str) -> Result<(), String> {
   let loaded    = load(path)?;
-  let kdl_names = to_kdl::get_kdl_names(&loaded.book)?;
-  let result    = to_kdl::to_kdl_book(&loaded.book, &kdl_names)?;
+  let comp_book = language::compile_book(&loaded.book);
+  let kdl_names = to_kdl::get_kdl_names(&comp_book)?;
+  let result    = to_kdl::to_kdl_book(&loaded.book, &kdl_names, &comp_book);
   print!("{}", result);
   Ok(())
 }
@@ -287,7 +288,7 @@ pub fn readback_string(rt: &hvm::Runtime, host: u64) -> String {
 // Generates a .hvm checker for a Book
 fn gen_checker(book: &Book) -> String {
   // Compile the Kind2 file to HVM checker
-  let base_check_code = compile_book(&book);
+  let base_check_code = to_checker_book(&book);
   let mut check_code = CHECKER_HVM.to_string();
   check_code.push_str(&base_check_code);
   return check_code;

--- a/src/to_kdl.rs
+++ b/src/to_kdl.rs
@@ -1,188 +1,120 @@
-// TODO: linearize variables, adding dups
-// TODO: U120?
+// TODO: U120
+// TODO: Kindelia.IO
 
 use crate::language::{*};
-use std::collections::{HashSet, HashMap};
+use std::collections::HashMap;
 use rand::Rng;
 
 pub const KDL_NAME_LEN: usize = 12;
 
-pub fn to_kdl_term(kdl_names: &HashMap<String, String>, term: &Comp) -> Result<String, String> {
-  let term = match term {
-    Comp::Var { name } => {
+pub fn to_kdl_term(kdl_names: &HashMap<String, String>, term: &CompTerm) -> String {
+  match term {
+    CompTerm::Var { name } => {
       format!("{}", name)
     }
-    Comp::Lam { name, body } => {
-      let body = to_kdl_term(kdl_names, body)?;
+    CompTerm::Lam { name, body } => {
+      let body = to_kdl_term(kdl_names, body);
       format!("@{} {}", name, body)
     }
-    Comp::App { func, argm } => {
-      let func = to_kdl_term(kdl_names, func)?;
-      let argm = to_kdl_term(kdl_names, argm)?;
+    CompTerm::App { func, argm } => {
+      let func = to_kdl_term(kdl_names, func);
+      let argm = to_kdl_term(kdl_names, argm);
       format!("({} {})", func, argm)
     }
-    Comp::Dup { nam0, nam1, expr, body } => {
-      let expr = to_kdl_term(kdl_names, expr)?;
-      let body = to_kdl_term(kdl_names, body)?;
+    CompTerm::Dup { nam0, nam1, expr, body } => {
+      let expr = to_kdl_term(kdl_names, expr);
+      let body = to_kdl_term(kdl_names, body);
       format!("dup {} {} = {}; {}", nam0, nam1, expr, body)
     }
-    Comp::Let { name, expr, body } => {
-      let expr = to_kdl_term(kdl_names, expr)?;
-      let body = to_kdl_term(kdl_names, body)?;
+    CompTerm::Let { name, expr, body } => {
+      let expr = to_kdl_term(kdl_names, expr);
+      let body = to_kdl_term(kdl_names, body);
       format!("let {} = {}; {}", name, expr, body)
     }
-    Comp::Ctr { name, args } => {
-      let kdl_name = kdl_names.get(name).unwrap();
-      let args = args.iter().map(|x| to_kdl_term(kdl_names, x)).collect::<Result<Vec<String>, String>>()?;
-      let args = args.iter().map(|x| format!(" {}", x)).collect::<String>();
+    CompTerm::Ctr { name, args } => {
+      let kdl_name = kdl_names.get(name).expect(&format!("{}", name));
+      let args = args.iter().map(|x| format!(" {}", to_kdl_term(kdl_names, x))).collect::<String>();
       format!("{{{}{}}}", kdl_name, args)
     }
-    Comp::Fun { name, args } => {
-      let kdl_name = kdl_names.get(name).unwrap();
-      let args = args.iter().map(|x| to_kdl_term(kdl_names, x)).collect::<Result<Vec<String>, String>>()?;
-      let args = args.iter().map(|x| format!(" {}", x)).collect::<String>();
-      format!("{{{}{}}}", kdl_name, args)
+    CompTerm::Fun { name, args } => {
+      let kdl_name = kdl_names.get(name).expect(&format!("{}", name));
+      let args = args.iter().map(|x| format!(" {}", to_kdl_term(kdl_names, x))).collect::<String>();
+      format!("({}{})", kdl_name, args)
     }
-    Comp::Num { numb } => {
+    CompTerm::Num { numb } => {
       format!("#{}", numb)
     }
-    Comp::Op2 { oper, val0, val1 } => {
+    CompTerm::Op2 { oper, val0, val1 } => {
       let oper = show_oper(&oper);
-      let val0 = to_kdl_term(kdl_names, val0)?;
-      let val1 = to_kdl_term(kdl_names, val1)?;
+      let val0 = to_kdl_term(kdl_names, val0);
+      let val1 = to_kdl_term(kdl_names, val1);
       format!("({} {} {})", oper, val0, val1)
     }
-    Comp::Nil => {
-      return Err("Found invalid Nil term".to_string());
+    CompTerm::Nil => {
+      panic!("Found nil term in compiled term while converting to kindelia");
     }
-  };
-  Ok(term)
-}
-
-pub fn to_kdl_oper(oper: &Oper) -> String {
-  match oper {
-    Oper::Add => format!("+"),
-    Oper::Sub => format!("-"),
-    Oper::Mul => format!("*"),
-    Oper::Div => format!("/"),
-    Oper::Mod => format!("%"),
-    Oper::And => format!("&"),
-    Oper::Or  => format!("|"),
-    Oper::Xor => format!("^"),
-    Oper::Shl => format!("<<"),
-    Oper::Shr => format!(">>"),
-    Oper::Ltn => format!("<"),
-    Oper::Lte => format!("<="),
-    Oper::Eql => format!("=="),
-    Oper::Gte => format!(">="),
-    Oper::Gtn => format!(">"),
-    Oper::Neq => format!("!="),
   }
 }
 
-pub fn to_kdl_rule(book: &Book, kdl_names: &HashMap<String, String>, rule: &Rule) -> Result<String, String> {
+pub fn to_kdl_rule(book: &Book, kdl_names: &HashMap<String, String>, rule: &CompRule) -> String {
   let name = &rule.name;
   let kdl_name = kdl_names.get(name).unwrap();
-  let entry = book.entrs.get(name).unwrap();
   let mut pats = vec![]; // stringified pattern args
-  let mut vars = HashSet::new(); // rule pattern vars
-  for (arg, pat) in entry.args.iter().zip(rule.pats.iter()) {
-    if !arg.eras {
-      let comp_pat = erase(book, pat);
-      let pat = match to_kdl_term(kdl_names, &comp_pat) {
-        Ok(term) => term,
-        Err(_)   => {
-          let pats = rule.pats.iter().map(|pat| format!(" {}", show_term(pat))).collect::<String>();
-          let err  = format!("Found invalid term in pattern \"{}\" of rule \"{}{}\"", show_term(&*pat), name, pats);
-          return Err(err);
-        },
-      };
-      pats.push(" ".to_string());
-      pats.push(pat);
-      collect_lhs_vars(&comp_pat, &mut vars);
-    }
+  for pat in rule.pats.iter() {
+    let pat = to_kdl_term(kdl_names, &pat);
+    pats.push(" ".to_string());
+    pats.push(pat);
   }
-  let mut body = erase(book, &rule.body);
-  let mut fresh = 0;
-  for mut var in vars.drain() {
-    let original_var = var.clone();
-    let uses = linearize_name(&mut body, &mut var, &mut fresh); // linearizes rule pattern vars
-    // The &mut here doesn't do anything because
-    // we're dropping var immediately afterwards.
-    // To linearize rule variables, we'll have to replace all LHS occurrences by ~
-    // if the amount of uses is zero
-    if uses == 0 {
-      for name in pats.iter_mut() {
-        if &*name == &original_var {
-          *name = String::from("~");
-        }
-      }
-    }
-    // The reason why we don't simply pass a real mutable reference to our variable
-    // (instead of a mutable reference of a clone) 
-    // to linearize_name is because since `var` is in `body`, we would 
-    // be borrowing `var` mutably twice, which is not allowed.
-    
-    // The reason why linearize_name takes in a mutable reference is
-    // to replace unused vars by ~. This is useful, for example, in 
-    // lambdas. (@x0 #0 should be linearized to @~ #0)
-  }
-  linearize(&mut body, &mut fresh); // linearizes internal bound vars
-  let body = match to_kdl_term(kdl_names, &body) {
-    Ok(body) => body,
-    Err(_)   => {
-      let pats = rule.pats.iter().map(|pat| format!(" {}", show_term(pat))).collect::<String>();
-      let err  = format!("Found invalid term in body of rule \"{}{}\"", name, pats);
-      return Err(err);
-    },
-  };
+  let body = to_kdl_term(kdl_names, &rule.body);
   let rule = format!("({}{}) = {}", kdl_name, pats.join(""), body);
-  Ok(rule)
+  rule
 }
 
-pub fn to_kdl_entry(book: &Book, kdl_names: &HashMap<String, String>, entry: &Entry) -> Result<String, String> {
-  let kdl_name  = kdl_names.get(&entry.name).unwrap();
-  let kind_name = format!("{} #{}", entry.name, kdl_name);
-  let mut args_typed = vec![];
-  let mut args_names = vec![];
-  for arg in &entry.args {
-    args_typed.push(format!(" {}({}: {})", if arg.eras { "-" } else { "" }, arg.name, show_term(&arg.tipo)));
-    if !arg.eras {
-      args_names.push(format!(" {}", arg.name));
-    }
-  }
-  // Entries with no rules become constructors
-  let entry = if entry.rules.is_empty() {
-    let cmnt = format!("// {}{} : {}\n", kind_name, args_typed.join(""), show_term(&entry.tipo));
-    let ctr  = format!("ctr {{{}{}}}\n\n", kdl_name, args_names.join(""));
-    cmnt + &ctr
-  // Entries with rules become functions
+pub fn to_kdl_entry(book: &Book, kdl_names: &HashMap<String, String>, entry: &CompEntry) -> String {
+  // Main is compiled to a run block
+  // TODO: Maybe we should have run blocks come from a specific type of function instead
+  if entry.name == "Main" {
+    let body = to_kdl_term(kdl_names, &*entry.rules[0].body);
+    format!("run {{\n  {}\n}}\n\n", body)
   } else {
-    let mut rules = vec![];
-    for rule in &entry.rules {
-      rules.push(format!("\n  {}", to_kdl_rule(book, kdl_names, rule)?));
-    }
-    let cmnt = format!("// {}{} : {}\n", kind_name, args_typed.join(""), show_term(&entry.tipo));
-    let func = format!("fun ({}{}) {{{}\n}}\n\n", kdl_name, args_names.join(""), rules.join(""));
-    cmnt + &func
-  };
-  Ok(entry)
+    let kdl_name      = kdl_names.get(&entry.name).unwrap();
+    let args_names    = entry.args.iter().map(|arg| format!(" {}", arg)).collect::<String>();
+    // If this entry existed in the original kind code, add some annotations as comments
+    let kind_entry    = book.entrs.get(&entry.name);
+    let is_kind_entry = matches!(kind_entry, Some(_));
+    let cmnt = if is_kind_entry {
+      let kind_entry = kind_entry.unwrap();
+      let args_typed = kind_entry.args.iter().map(|arg|
+        format!(" {}({}: {})", if arg.eras { "-" } else { "" }, arg.name, show_term(&arg.tipo))
+      ).collect::<String>();
+      let kind_name  = format!("{} #{}", entry.name, kdl_name);
+      format!("// {}{} : {}\n", kind_name, args_typed, show_term(&kind_entry.tipo))
+    } else {
+      String::new()
+    };
+    // Entries with no rules become constructors
+    // Entries with rules become functions
+    let fun = if entry.rules.is_empty() {
+      format!("ctr {{{}{}}}\n\n", kdl_name, args_names)
+    } else {
+      let mut rules = vec![];
+      for rule in &entry.rules {
+        rules.push(format!("\n  {}", to_kdl_rule(book, kdl_names, rule)));
+      }
+      format!("fun ({}{}) {{{}\n}}\n\n", kdl_name, args_names, rules.join(""))
+    };
+    let entry = cmnt + &fun;
+    entry
+  }
 }
 
-pub fn to_kdl_book(book: &Book, kdl_names: &HashMap<String, String>) -> Result<String, String> {
+pub fn to_kdl_book(book: &Book, kdl_names: &HashMap<String, String>, comp_book: &CompBook) -> String {
   let mut lines = vec![];
-  for name in &book.names {
-    let entry = book.entrs.get(name).unwrap();
-    // Skip over useless entries
-    // TODO: This doesn't cover all cases. We need something like `erase` but for a Book.
-    //       Also maybe there are functions of type Type that should be compiled?
-    if let Term::Typ {orig: _} = &*entry.tipo {
-      continue;
-    } else {
-      lines.push(to_kdl_entry(book, kdl_names, entry)?);
-    }
+  for name in &comp_book.names {
+    let entry = comp_book.entrs.get(name).unwrap();
+    lines.push(to_kdl_entry(book, kdl_names, entry));
   }
-  Ok(lines.join(""))
+  lines.join("")
 }
 
 // Utils
@@ -190,75 +122,76 @@ pub fn to_kdl_book(book: &Book, kdl_names: &HashMap<String, String>) -> Result<S
 
 // Returns a map of kind names to kindelia names
 // Returns an err if any of the names can't be converted
-pub fn get_kdl_names(book: &Book) -> Result<HashMap<String, String>, String> {
-  fn get_kdl_name(entry: &Entry) -> Result<String, String> {
-    let kind_name = &entry.name;
-    // If the entry uses a kindelia name, use it
-    if let Some(kdln) = &entry.kdln {
-      // If the name has no ., put one at the start to make it part of the root namespace
-      if kdln.len() > KDL_NAME_LEN {
-        let err = format!("Kindelia name \"{}\" for \"{}\" has more than {} characters.", kdln, kind_name, KDL_NAME_LEN - 1);
-        return Err(err);
-      }
-      Ok(kdln.clone())
-    // Otherwise, try to fit the normal kind name in the max allowed len
+pub fn get_kdl_names(book: &CompBook) -> Result<HashMap<String, String>, String> {
+  // Fits a name to the max size allowed by kindelia.
+  // If the name is too large, truncates and replaces the last characters by random chars.
+  // Fails if the namespace is too large.
+  fn rand_shorten(name: &String) -> Result<String, String> {
+    let (ns, fun) = name.rsplit_once('.').unwrap_or(("", name));
+    let  ns       = if !ns.is_empty() { format!("{}.", ns) } else { ns.to_string() };
+    if ns.len() > KDL_NAME_LEN - 1 {
+      let err = format!("Namespace for \"{}\" has more than {} characters.", name, KDL_NAME_LEN - 1);
+      return Err(err);
+    }
+    let max_fn_name = KDL_NAME_LEN - ns.len();
+    // If the name doesn't fit, truncate and insert some random characters at the end
+    let fun = if fun.len() > max_fn_name {
+      let n_rnd_chrs = usize::min(3, max_fn_name);
+      let fun_cut    = fun[..max_fn_name - n_rnd_chrs].to_string();
+      let mut rng    = rand::thread_rng();
+      let rnd_chrs   = (0..n_rnd_chrs)
+                        .map(|_| rng.gen_range(0..63))
+                        .map(|n| encode_base64(n))
+                        .collect::<String>();
+      format!("{}{}", fun_cut, rnd_chrs)
     } else {
-      let (ns, fun) = kind_name.rsplit_once('.').unwrap_or(("", kind_name));
-      let  ns       = if !ns.is_empty() { format!("{}.", ns) } else { ns.to_string() };
-      if ns.len() > KDL_NAME_LEN - 1 {
-        let err = format!("Namespace for \"{}\" has more than {} characters.", kind_name, KDL_NAME_LEN - 1);
-        return Err(err);
-      }
-      let max_fn_name = KDL_NAME_LEN - ns.len();
-      // If the name doesn't fit, truncate and insert some random characters at the end
-      let fun = if fun.len() > max_fn_name {
-        let n_rnd_chrs = usize::min(3, max_fn_name);
-        let fun_cut    = fun[..max_fn_name - n_rnd_chrs].to_string();
-        let mut rng    = rand::thread_rng();
-        let rnd_chrs   = (0..n_rnd_chrs)
-                          .map(|_| rng.gen_range(0..63))
-                          .map(|n| encode_base64(n))
-                          .collect::<String>();
-        format!("{}{}",fun_cut, rnd_chrs)
-      } else {
-        fun.to_string()
-      };
-      Ok(format!("{}{}", ns, fun))
+      fun.to_string()
+    };
+    Ok(format!("{}{}", ns, fun))
+  }
+
+  fn get_kdl_name(entry: &CompEntry) -> Result<String, String> {
+    let kind_name = &entry.name;
+    let kdln = match &entry.kdln {
+      Some(kdln) => {
+        // If the entry uses a kindelia name, use it
+        if !kdln.chars().next().unwrap().is_uppercase() {
+          let err = format!("Kindelia name \"{}\" doesn't start with an uppercase letter.", kdln);
+          return Err(err);
+        }
+        if entry.orig {
+          if kdln.len() > KDL_NAME_LEN {
+            let err = format!("Kindelia name \"{}\" for \"{}\" has more than {} characters.", kdln, kind_name, KDL_NAME_LEN - 1);
+            return Err(err);
+          }
+          kdln.clone()
+        } else {
+          // For entries created by the flattener, we shorten even the kindelia name
+          // TODO: Since these rules can come first,
+          //       if the kdln is too large the err will happen in the generated function,
+          //       potentially confusing the user.
+          rand_shorten(kdln)?
+        }
+      },
+      // Otherwise, try to fit the normal kind name
+      None => rand_shorten(kind_name)?,
+    };
+    Ok(kdln)
+  }
+
+  fn encode_base64(num: u8) -> char {
+    match num {
+      0  ..= 9  => (num      + b'0') as char,
+      10 ..= 35 => (num - 10 + b'A') as char,
+      36 ..= 61 => (num - 36 + b'a') as char,
+      62 ..     => '_',
     }
   }
+
   let mut kdl_names = HashMap::new();
   for name in &book.names {
     let kdln = get_kdl_name(book.entrs.get(name).unwrap())?;
     kdl_names.insert(name.clone(), kdln);
   }
   Ok(kdl_names)
-}
-
-pub fn encode_base64(num: u8) -> char {
-  match num {
-    0  ..= 9  => (num      + b'0') as char,
-    10 ..= 35 => (num - 10 + b'A') as char,
-    36 ..= 61 => (num - 36 + b'a') as char,
-    62 ..     => '_',
-  }
-}
-
-// Returns left-hand side variables
-pub fn collect_lhs_vars(term: &Comp, vars: &mut HashSet<String>) {
-  match term {
-    Comp::Var { name } => {
-      vars.insert(name.clone());
-    }
-    Comp::App { func, argm } => {
-      collect_lhs_vars(func, vars);
-      collect_lhs_vars(argm, vars);
-    }
-    Comp::Ctr { args, .. } => {
-      for arg in args {
-        collect_lhs_vars(arg, vars);
-      }
-    }
-    Comp::Num { .. } => {}
-    _ => { panic!("Invalid left-hand side."); }
-  }
 }


### PR DESCRIPTION
Add rule flattening to the kindelia compiler.
The algorithm is copied from the HVM, but instead of `RuleGroup`s, we use `Entry`s that get compiled to `fun` blocks.

Fix a bug where the variable linearizer didn't unbind variables inside constructors on the lhs of rules.

Rename type checker compiler functions to `to_checker_...`.

Separate kindelia compilation (`compile_...` functions and `Comp...` structures) from stringification (`to_kdl_...` functions).
This compiler could also be used for HVM compilation in the future.

Reorganize some of the compilation code, adding other compiled structures besides `Term`s and slightly refactoring linearization code.

The new functions don't check for code errors and panic when the user provides incorrect code, like with functions that need types during runtime.