### PR TITLE
Handle U120 properly on kindelia compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "kind2"
-version = "0.2.74"
+version = "0.2.75"
 dependencies = [
  "clap",
  "highlight_error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "kind2"
-version = "0.2.71"
+version = "0.2.74"
 dependencies = [
  "clap",
  "highlight_error",

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,9 +161,9 @@ fn cmd_show(path: &str) -> Result<(), String> {
 // Compiles a file to Kindelia (.kdl)
 fn cmd_to_kdl(path: &str) -> Result<(), String> {
   let loaded    = load(path)?;
-  let comp_book = language::compile_book(&loaded.book);
+  let comp_book = language::compile_book(&loaded.book)?;
   let kdl_names = to_kdl::get_kdl_names(&comp_book)?;
-  let result    = to_kdl::to_kdl_book(&loaded.book, &kdl_names, &comp_book);
+  let result    = to_kdl::to_kdl_book(&loaded.book, &kdl_names, &comp_book)?;
   print!("{}", result);
   Ok(())
 }

--- a/src/to_kdl.rs
+++ b/src/to_kdl.rs
@@ -115,8 +115,7 @@ pub fn to_kdl_book(book: &Book, kdl_names: &HashMap<String, String>, comp_book: 
   let mut lines = vec![];
   for name in &comp_book.names {
     let entry = comp_book.entrs.get(name).unwrap();
-    let entry = to_kdl_entry(book, kdl_names, entry)?;
-    lines.push(entry);
+    lines.push(to_kdl_entry(book, kdl_names, entry)?);
   }
   Ok(lines.join(""))
 }


### PR DESCRIPTION
(U120.new num num) becomes a primitive num, (U120.op num num) becomes a primitive op2.

Compilation fails on lhs (U120.new var _).

Will still panic on some invalid inputs. Still need to do something about U60s.