### PR TITLE
Accept multiple files on check command

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -157,11 +157,19 @@ pub fn cmd_derive(config: &Config, path: &str) -> Result<(), String> {
     Ok(())
 }
 
-pub fn cmd_check_all(config: &Config, path: &str) -> Result<(), String> {
-    let loaded = load(config, path)?;
-    let result = run_with_hvm(&gen_checker(&loaded.book), "Kind.API.check_all", true)?;
-    print!("{}", inject_highlights(&loaded.file, &result.output));
-    println!("Rewrites: {}", result.rewrites);
+// Checks all definitions of multiple Kind2 files
+pub fn cmd_check_all(config: &Config, paths: Vec<String>) -> Result<(), String> {
+    fn check_file (config: &Config, path: &str) -> Result<(), String> {
+        println!("\x1b[1mFile: {}\x1b[0m", &path);
+        let loaded = load(config, path)?;
+        let result = run_with_hvm(&gen_checker(&loaded.book), "Kind.API.check_all", true)?;
+        print!("{}", inject_highlights(&loaded.file, &result.output));
+        println!("Rewrites: {}\n", result.rewrites);
+        Ok(())
+    }
+    for path in paths {
+        check_file(config, &path)?;
+    }
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ pub struct Cli {
 pub enum Command {
     /// Check a file
     #[clap(aliases = &["c"])]
-    Check { file: String },
+    Check { files: Vec<String> },
 
     /// Evaluates Main on Kind2
     #[clap(aliases = &["r"])]
@@ -74,7 +74,7 @@ fn run_cli() -> Result<(), String> {
     match cli_matches.command {
         Command::Eval { file: path } => cmd_eval_main(&config, &path),
         Command::Run { file: path } => cmd_run_main(&config, &path),
-        Command::Check { file: path } => cmd_check_all(&config, &path),
+        Command::Check { files: paths } => cmd_check_all(&config, paths),
         Command::Derive { file: path } => cmd_derive(&config, &path),
         Command::GenChecker { file: path } => cmd_gen_checker(&config, &path),
         Command::Show { file: path } => cmd_show(&config, &path),


### PR DESCRIPTION
Useful to check all files in a folder after adding many things or changing something that could break many other functions.