### PR TITLE
Accept more cases of inlined functions

### DIFF
--- a/src/codegen/kdl.rs
+++ b/src/codegen/kdl.rs
@@ -25,7 +25,7 @@ pub fn stringify_kdl_term(kdl_names: &HashMap<Ident, Ident>, term: &CompTerm) ->
         CompTerm::Dup { nam0, nam1, expr, body } => {
             let expr = stringify_kdl_term(kdl_names, expr)?;
             let body = stringify_kdl_term(kdl_names, body)?;
-            format!("dup {} {} = {}; {}", nam0, nam1, expr, body)
+            format!("dup {} {} = {};\n    {}", nam0, nam1, expr, body)
         }
         CompTerm::Let { name, expr, body } => {
             let expr = stringify_kdl_term(kdl_names, expr)?;

--- a/tests/suite/to_kdl/inline_simple.golden
+++ b/tests/suite/to_kdl/inline_simple.golden
@@ -1,0 +1,28 @@
+// MyType.new -(t: Type) -(u: Type) (a: U60) (b: U60) (c: t) (d: u) : (MyType t u)
+ctr {MyType_new a b c d}
+
+// MyType.swap -(t: Type) -(u: Type) (a: (MyType t u)) : (MyType u t)
+fun (MyType_swap a) {
+  (MyType_swap {MyType_new a b c d}) =
+    {MyType_new b a d c}
+}
+
+// MyType.mix -(t: Type) -(u: Type) (a: (MyType t u)) (b: (MyType t u)) : (MyType t u)
+fun (MyType_mix a b) {
+  (MyType_mix {MyType_new aa ~ ac ~} {MyType_new ~ bb ~ bd}) =
+    {MyType_new aa bb ac bd}
+}
+
+// MyType.get_c -(t: Type) -(u: Type) (a: (MyType t u)) : t
+fun (MyType_get_c a) {
+  (MyType_get_c {MyType_new ~ ~ c ~}) =
+    c
+}
+
+// Main : _
+fun (Main) {
+  (Main) =
+    let a = {MyType_new #0 #1 #2 #3};
+    (MyType_get_c (MyType_mix a (MyType_swap (!@x {MyType_new x #5 #6 #7} #4))))
+}
+

--- a/tests/suite/to_kdl/inline_simple.kind2
+++ b/tests/suite/to_kdl/inline_simple.kind2
@@ -1,0 +1,22 @@
+MyType (t: Type) (u: Type) : Type
+MyType.new <t> <u> (a: U60) (b: U60) (c: t) (d: u) : MyType t u
+
+MyType.swap <t> <u> (a: MyType t u) : MyType u t
+MyType.swap (MyType.new a b c d) = MyType.new b a d c
+
+MyType.mix <t> <u> (a: MyType t u) (b: MyType t u) : MyType t u
+MyType.mix (MyType.new aa ab ac ad) (MyType.new ba bb bc bd) =
+  MyType.new aa bb ac bd
+
+MyType.get_c <t> <u> (a: MyType t u) : t
+MyType.get_c (MyType.new a b c d) = c
+
+#inline
+SimpleFn <t> <u> (a: MyType t u) (b: MyType u t) : t {
+  MyType.get_c (MyType.mix a (MyType.swap b))
+}
+
+Main {
+  let a = (MyType.new 0 1 2 3)
+  SimpleFn a ((x => MyType.new x 5 6 7) 4)
+}


### PR DESCRIPTION
We can now always inline functions that have only one rule that matches exclusively against variables.

This corresponds to functions written with the `{...}` syntax instead of explicit rules like:
```
MySimpleFn (a: U60) {
  (* a a)
}
```