### PR TITLE
V2 operations

### DIFF
--- a/book/Nat/half.kind2
+++ b/book/Nat/half.kind2
@@ -27,7 +27,7 @@ match n {
     succ: (succ (half n.pred.pred))
     zero: zero
   }
-  zero: (succ zero)
+  zero: zero
 }
 
 

--- a/book/Nat/sqrt.kind2
+++ b/book/Nat/sqrt.kind2
@@ -1,0 +1,26 @@
+use U48/{to_nat,from_nat}
+use Nat/{add,half,equal}
+use Bool/{true,false}
+
+sqrt
+- n: Nat
+- guess: Nat
+- old_guess: Nat
+: Nat
+
+let n_u48 = (from_nat n)
+let guess_u48 = (from_nat guess)
+
+let n_div_guess = (to_nat (/ n_u48 guess_u48))
+let guess_plus_n_div = (add n_div_guess guess)
+
+let new_guess = (half guess_plus_n_div)
+
+let eq = (equal new_guess old_guess)
+
+match eq {
+  true: new_guess
+  false: (Nat/sqrt n new_guess guess)
+}
+
+

--- a/book/U48/sqrt.kind2
+++ b/book/U48/sqrt.kind2
@@ -1,1 +1,28 @@
-// TODO
+/// Calculates the integer square root of a given number using Newton's method.
+///
+/// This function implements an iterative approach to find the square root,
+/// starting with an initial guess and refining it until convergence.
+///
+/// # Input
+///
+/// * `n` - The number for which to calculate the square root.
+///
+/// # Output
+///
+/// Returns the calculated integer square root of `n`.
+///
+/// # Algorithm
+///
+/// 1. If n is 0 or 1, return n as its own square root.
+/// 2. For n > 1, use n/2 as the initial guess.
+
+// if true returns 1, else return false (0)
+
+use U48/sqrt/{go}
+
+sqrt
+- n: U48
+: U48
+
+(go n (/ n 2) n)
+

--- a/book/U48/sqrt/go.kind2
+++ b/book/U48/sqrt/go.kind2
@@ -18,17 +18,33 @@
 /// 1. Calculate a new guess using the formula: (guess + n/guess) / 2
 /// 2. If the new guess equals the previous guess, we've converged; return the guess.
 /// 3. Otherwise, recurse with the new guess as the current guess and the old guess as the previous guess.
+/// FIXME: find a way to do without nat conversion. The conventional algorithm was running forever for u48 for some reason
 
-// TODO: review
+use U48/{to_nat,from_nat}
+use Nat/{add,half,equal}
+use Bool/{true,false}
 
 go
 - n: U48
 - guess: U48
-- prev_guess: U48
+- old_guess: U48
 : U48
 
-let new_guess = (/ (+ guess (/ n guess)) 2)
-switch x = (== guess prev_guess) {
-  0: guess
-  _: (U48/sqrt/go n new_guess guess)
+let n_nat = (to_nat n)
+let guess_nat = (to_nat guess)
+let old_guess_nat = (to_nat old_guess)
+
+let n_div_guess = (to_nat (/ n guess))
+let guess_plus_n_div = (add n_div_guess guess_nat)
+
+let new_guess_nat = (half guess_plus_n_div)
+
+let eq = (equal new_guess_nat old_guess_nat)
+let next_guess = (from_nat new_guess_nat)
+
+match eq {
+  true: (from_nat new_guess_nat)
+  false: (U48/sqrt/go n next_guess guess)
 }
+
+

--- a/book/U48/to_nat.kind2
+++ b/book/U48/to_nat.kind2
@@ -1,0 +1,10 @@
+use Nat/{succ,zero}
+
+to_nat
+- n: U48
+: Nat
+
+switch n {
+  0: zero
+  _: (succ (to_nat (- n 1)))
+}

--- a/book/V2/dist.kind2
+++ b/book/V2/dist.kind2
@@ -1,0 +1,21 @@
+/// Calculates the distance between two V2 vectors.
+/// Equivalent to the square root of sqr_dist
+/// # Input
+///
+/// * `a` - The first V2 vector
+/// * `b` - The second V2 vector
+///
+/// # Output
+///
+/// The distance between `a` and `b` as a U48
+
+use V2/{new,sqr_dist}
+use U48/{sqrt}
+
+dist
+- a: V2
+- b: V2
+: U48
+
+let sqr_dst = (sqr_dist a b)
+(sqrt sqr_dst)

--- a/book/V2/div_scalar.kind2
+++ b/book/V2/div_scalar.kind2
@@ -1,0 +1,22 @@
+/// Divides a V2 vector by a scalar.
+///
+/// # Input
+///
+/// * `a` - The first V2 vector (dividend)
+/// * `s` - The U48 scalar (divisor)
+///
+/// # Output
+///
+/// A new V2 vector representing the component-wise division of `a` by `s`
+/// Note: This function does not handle division by zero.
+
+use V2/{new}
+
+div_scalar
+- a: V2
+- s: U48
+: V2
+
+match a {
+  new: (new (/ a.x s) (/ a.y s))
+}

--- a/book/V2/length.kind2
+++ b/book/V2/length.kind2
@@ -1,0 +1,23 @@
+/// Calculates the length (magnitude) of a V2 vector using Euclidean norm.
+///
+/// # Input
+///
+/// * `a` - The first V2 vector
+///
+/// # Output
+///
+/// The length of the V2 vector `a` as a U48
+
+use V2/{new}
+use U48/{sqrt}
+
+length
+- a: V2
+: U48
+
+match a {
+  new:
+    let x_sqr = (* a.x a.x)
+    let y_sqr = (* a.y a.y)
+    (sqrt (+ x_sqr y_sqr)) 
+}

--- a/book/V2/linear_interpolation.kind2
+++ b/book/V2/linear_interpolation.kind2
@@ -1,0 +1,30 @@
+/// Calculates the linear interpolation between two V2 vecctors given a parameter `t`.
+///
+/// # Input
+///
+/// * `a` - The first V2 vector
+/// * `b` - The second V2 vector
+/// * `t` - The interpolation parameter (in theory 0 <= t <= 1, when we have floats)
+///
+/// # Output
+///
+/// A V2 vector containing the interpolated x and y coordinates. 
+
+use V2/{new}
+
+// kinda useless when having no floats. if t = 0, we will get the first vec, if t = 1 we will get the second
+linear_interpolation
+- a: V2
+- b: V2
+- t: U48
+: V2
+
+match a {
+  new: match b {
+    new: 
+      let interpol_x = (+ a.x (* t (- b.x a.x)))
+      let interpol_y = (+ a.y (* t (- b.y a.y)))
+      (new interpol_x interpol_y)
+  }
+}
+

--- a/book/V2/max.kind2
+++ b/book/V2/max.kind2
@@ -1,0 +1,41 @@
+/// Get the max vector between two V2 vectors component-wise.
+///
+/// # Input
+///
+/// * `a` - The first V2 vector
+/// * `b` - The second V2 vector
+///
+/// # Output
+///
+/// A new V2 vector representing the min vector between those two.
+/// Example: a = (3 , 7) b = (5 , 2) -> out = (5 , 7)
+
+use V2/{new}
+use Cmp/{is_gtn}
+use Bool/{true,false}
+use V2/{get_x,get_y}
+
+max
+- a: V2
+- b: V2
+: V2
+
+let ax = (get_x a)
+let ay = (get_y a)
+
+let bx = (get_x b)
+let by = (get_y b)
+
+let x = (U48/to_bool (< ax bx))
+let y = (U48/to_bool (< ay by))
+
+match x with (y: Bool) {
+  true: match y {
+    true: (V2/new bx by)
+    false: (V2/new bx ay)
+  }
+  false: match y {
+    true: (V2/new ax by)
+    false: (V2/new ax ay)
+  }
+}

--- a/book/V2/min.kind2
+++ b/book/V2/min.kind2
@@ -1,0 +1,41 @@
+/// Get the min vector between two V2 vectors component-wise.
+///
+/// # Input
+///
+/// * `a` - The first V2 vector
+/// * `b` - The second V2 vector
+///
+/// # Output
+///
+/// A new V2 vector representing the min vector between those two.
+/// Example: a = (3 , 7) b = (5 , 2) -> out = (3 , 2)
+
+use V2/{new}
+use Cmp/{is_gtn}
+use Bool/{true,false}
+use V2/{get_x,get_y}
+
+min
+- a: V2
+- b: V2
+: V2
+
+let ax = (get_x a)
+let ay = (get_y a)
+
+let bx = (get_x b)
+let by = (get_y b)
+
+let x = (U48/to_bool (< ax bx))
+let y = (U48/to_bool (< ay by))
+
+match x with (y: Bool) {
+  true: match y {
+    true: (V2/new ax ay)
+    false: (V2/new ax by)
+  }
+  false: match y {
+    true: (V2/new bx ay)
+    false: (V2/new bx by)
+  }
+}

--- a/book/V2/normalize.kind2
+++ b/book/V2/normalize.kind2
@@ -1,0 +1,22 @@
+///  Normalizes a vector
+///
+/// # Input
+///
+/// * `a` - The first V2 vector
+///
+/// # Output
+///
+/// The normalized V2 vector `a`
+/// Obs: this function does NOT check if its possible normalize (vector should be != (0, 0)). This operation also makes more sense with Floats.
+
+use V2/{new,length}
+
+normalize
+- a: V2
+: V2
+
+match a {
+  new:
+    let len = (length a)
+    (new (/ a.x len) (/ a.y len))
+}

--- a/book/V2/perpendicular.kind2
+++ b/book/V2/perpendicular.kind2
@@ -1,0 +1,20 @@
+/// Finds a V2 vector perpendicular to the input V2 vector `a`. 
+///
+/// # Input
+///
+/// * `a` - A V2 vector
+///
+/// # Output
+///
+/// A V2 vector perpendicular to A
+
+use V2/{new}
+
+perpendicular
+- a: V2
+: V2
+
+match a {
+  new:
+    (new (- 0 a.y) a.x)
+}


### PR DESCRIPTION
Adds simple linear algebra v2 operations to `V2` type.

It also implements `sqrt` for nats and I reimplemented using nat conversion for U48 (for some reason U48 recursion was not working?)

I was mainly learning Kind's syntax and trying some stuff out.

Also the `Nat/half` function was modified in the commit before mines, but it seems like it was incorrect. Half 4 was resulting in 3, half 2 in 2, so I removed the succ call in the zero case.