### PR TITLE
Add record update syntax

### DIFF
--- a/src/Kind/Check.hs
+++ b/src/Kind/Check.hs
@@ -13,6 +13,7 @@ import qualified Data.IntMap.Strict as IM
 import qualified Data.Map.Strict as M
 
 import Control.Monad (forM, forM_, unless, when)
+import Data.Foldable (find)
 import Debug.Trace
 
 -- Type-Checking
@@ -176,6 +177,10 @@ infer sus src term dep = debug ("infer:" ++ (if sus then "* " else " ") ++ showT
   go (Con nam arg) = do
     envLog (Error src (Ref "annotation") (Ref "constructor") (Con nam arg) dep)
     envFail
+  
+  go (Upd trm args) = do
+    envLog (Error src (Ref "annotation") (Ref "record update") (Upd trm args) dep)
+    envFail
 
   go (Mat cse) = do
     envLog (Error src (Ref "annotation") (Ref "match") (Mat cse) dep)
@@ -290,6 +295,54 @@ check sus src term typx dep = debug ("check:" ++ (if sus then "* " else " ") ++ 
       checkConstructor src _ _ dep = do
         envLog (Error src (Hol "arity_mismatch" []) (Hol "unknown_type" []) (Hol "constructor" []) dep)
         envFail
+
+  go val@(Upd trm arg) = do
+    book <- envGetBook
+    fill <- envGetFill
+    case reduce book fill 2 typx of
+      (ADT adtScp adtCts adtTyp) ->
+        case adtCts of
+          -- Exactly 1 constructor
+          [adtCts] -> do
+            let (Ctr _ cTel) = adtCts
+            let expectedFields = getFields cTel
+            let wrongField = find (not . (`elem` expectedFields)) (map fst arg)
+            case wrongField of
+              Just fld -> do
+                envLog (Error src (Hol ("expected_one_of:" ++ show expectedFields) []) (Hol ("detected:" ++ fld) []) (Hol "unknown_field" []) dep)
+                envFail
+              Nothing -> pure ()
+
+            argA <- checkConstructor src arg cTel dep
+            return $ Ann False (Upd trm argA) typx
+          _ -> do
+            -- 0 or more than 1 constructors
+            envLog $ Error src
+              (Hol ("expected: 1 constructor") [])
+              (Hol ("detected: " ++ show (length adtCts) ++ " constructors") []) 
+              (Hol ("record_update_multiple_constructors") []) dep
+            envFail
+
+      otherwise -> infer sus src (Upd trm arg) dep
+    where
+      getFields :: Tele -> [String]
+      getFields (TRet trm) = []
+      getFields (TExt fld trm f) = fld : getFields (f trm)
+
+      checkConstructor :: Maybe Cod -> [(String, Term)] -> Tele -> Int -> Env [(String, Term)]
+      checkConstructor src [] (TRet ret) dep = do
+        cmp src val ret typx dep
+        return []
+      checkConstructor src ((field, arg):args) (TExt nam inp bod) dep =
+        if field /= nam
+          then do
+            -- Constructors must be in order
+            checkConstructor src ((field, arg) : args) (bod arg) dep
+          else do
+            argA  <- check sus src arg inp dep
+            argsA <- checkConstructor src args (bod arg) (dep + 1)
+            return $ (field, argA) : argsA
+      checkConstructor src _ _ dep = return []
 
   go (Mat cse) = do
     book <- envGetBook

--- a/src/Kind/Parse.hs
+++ b/src/Kind/Parse.hs
@@ -183,7 +183,7 @@ parseTerm = do
     , (parseADT,             discard $ string_skp "#[" <|> string_skp "data[")
     , (parseNat,             discard $ string_skp "#" >> digit)
     , (parseCon,             discard $ string_skp "#" >> name)
-    , (parseUpd,             discard $ string_skp "record")
+    , (parseUpd,             discard $ string_skp "record ")
     , ((parseUse parseTerm), discard $ string_skp "use ")
     , ((parseLet parseTerm), discard $ string_skp "let ")
     , ((parseGet parseTerm), discard $ string_skp "get ")

--- a/src/Kind/Parse.hs
+++ b/src/Kind/Parse.hs
@@ -172,6 +172,7 @@ parseTerm = (do
     , parseADT
     , parseNat
     , parseCon
+    , parseUpd
     , (parseUse parseTerm)
     , (parseLet parseTerm)
     , (parseGet parseTerm)
@@ -302,6 +303,28 @@ parseCon = withSrc $ do
     char '}'
     return args
   return $ Con nam args
+
+parseUpd = withSrc $ do
+  string_skp "record"
+  skip
+
+  term <- parseTerm
+  skip
+
+  args <- P.option [] $ P.try $ do
+    skip
+    char_skp '{'
+    args <- P.many $ do
+      P.notFollowedBy (char_skp '}')
+      name <- do
+        name <- name_skp
+        char_skp ':'
+        return name
+      term <- parseTerm
+      return (name, term)
+    char '}'
+    return args
+  return $ Upd term args
 
 parseMatCases :: Parser [(String, Term)]
 parseMatCases = do

--- a/src/Kind/Show.hs
+++ b/src/Kind/Show.hs
@@ -66,6 +66,11 @@ showTermGo small term dep =
           showArg (maybeField, term) = case maybeField of
             Just field -> field ++ ": " ++ showTermGo small term dep
             Nothing -> showTermGo small term dep
+      Upd trm arg ->
+        let arg' = unwords (map showArg arg)
+        in concat ["record", " ", showTermGo small trm dep, " ", "{", arg', "}"]
+        where
+          showArg (field, term) = field ++ ": " ++ showTermGo small term dep
       Mat cse ->
         let cse' = unwords (map (\(cnm, cbod) -> "#" ++ cnm ++ ": " ++ showTermGo small cbod dep) cse)
         in concat ["λ{ ", cse', " }"]

--- a/src/Kind/Type.hs
+++ b/src/Kind/Type.hs
@@ -33,6 +33,9 @@ data Term
   -- Constructor: `#CN { x0 x1 ... }`
   | Con String [(Maybe String, Term)]
 
+  -- Record update syntax: `record x {a: 0 b: 1 ...}`
+  | Upd Term [(String, Term)]
+
   -- Lambda-Match: `λ{ #C0:B0 #C1:B1 ... }`
   | Mat [(String, Term)]
 

--- a/src/Kind/Util.hs
+++ b/src/Kind/Util.hs
@@ -26,6 +26,7 @@ getDeps term = case term of
   Ins val         -> getDeps val
   ADT scp cts t   -> concatMap getDeps scp ++ concatMap getDepsCtr cts ++ getDeps t
   Con _ arg       -> concatMap (getDeps . snd) arg
+  Upd trm arg     -> getDeps trm ++ concatMap (getDeps . snd) arg
   Mat cse         -> concatMap (getDeps . snd) cse
   Let _ val bod   -> getDeps val ++ getDeps (bod Set)
   Use _ val bod   -> getDeps val ++ getDeps (bod Set)


### PR DESCRIPTION
This PR adds syntax to update records without completely de-constructing and re-constructing them.

The added syntax is for example:
```
change : (Pair String String) -> (Pair String String)
| p = record p { fst: (String/append "hel" "lo") }
//    --------------------------------------------
```
I don't think @VictorTaelin will like the syntax like this, so I would like to hear some suggestions on how it should be.

The code in this PR already translates it into JS using object update syntax, which shouldn't be worse performance-wise than the previous method of creating a new record from scratch.

The reduction code for this term is not the best it could be. If there were an additional compilation stage to change terms after checking but before reducing, we could force every constructor to have all of its fields named and sorted (maybe inserted into a map), so the actual updating would be trivial and performant.